### PR TITLE
(Fix) Remove MM warning and fix white pending tx page

### DIFF
--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -10,10 +10,10 @@ restoreContextAfterImports()
 
 log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn')
 
-console.warn('ATTENTION: In an effort to improve user privacy, MetaMask will ' +
-'stop exposing user accounts to dapps by default beginning November 2nd, 2018. ' +
-'Dapps should call provider.enable() in order to view and use accounts. Please see ' +
-'https://bit.ly/2QQHXvF for complete information and up-to-date example code.')
+// console.warn('ATTENTION: In an effort to improve user privacy, MetaMask will ' +
+// 'stop exposing user accounts to dapps by default beginning November 2nd, 2018. ' +
+// 'Dapps should call provider.enable() in order to view and use accounts. Please see ' +
+// 'https://bit.ly/2QQHXvF for complete information and up-to-date example code.')
 
 //
 // setup plugin communication

--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -66,7 +66,9 @@ function mapStateToProps (state) {
 
 PendingTx.prototype.render = function () {
   const state = this.state
-  if (!state.tokenDataRetrieved) return null
+  if (this.props.isToken) {
+    if (!state.tokenDataRetrieved) return null
+  }
   const props = this.props
   const { currentCurrency, blockGasLimit, network, provider, isUnlocked } = props
 
@@ -588,7 +590,9 @@ PendingTx.prototype.miniAccountPanelForRecipient = function (isToken, tokensTran
 PendingTx.prototype.componentWillMount = function () {
   const txMeta = this.gatherTxMeta()
   const txParams = txMeta.txParams || {}
-  this.updateTokenInfo(txParams)
+  if (this.props.isToken) {
+    this.updateTokenInfo(txParams)
+  }
 }
 
 PendingTx.prototype.componentWillUnmount = function () {

--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -600,10 +600,15 @@ PendingTx.prototype.componentWillUnmount = function () {
 }
 
 PendingTx.prototype.updateTokenInfo = async function (txParams) {
-  const tokenParams = await this.tokenInfoGetter(txParams.to)
+  let tokenParams
+  try {
+    tokenParams = await this.tokenInfoGetter(txParams.to)
+  } catch (e) {
+    log.error(e)
+  }
   this.setState({
-    tokenSymbol: tokenParams.symbol,
-    tokenDecimals: tokenParams.decimals,
+    tokenSymbol: (tokenParams && tokenParams.symbol),
+    tokenDecimals: (tokenParams && tokenParams.decimals),
     tokenDataRetrieved: true,
   })
 }

--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -604,15 +604,10 @@ PendingTx.prototype.componentWillUnmount = function () {
 }
 
 PendingTx.prototype.updateTokenInfo = async function (txParams) {
-  let tokenParams
-  try {
-    tokenParams = await this.tokenInfoGetter(txParams.to)
-  } catch (e) {
-    log.error(e)
-  }
+  const tokenParams = await this.tokenInfoGetter(txParams.to)
   this.setState({
-    tokenSymbol: (tokenParams && tokenParams.symbol),
-    tokenDecimals: (tokenParams && tokenParams.decimals),
+    tokenSymbol: (tokenParams.symbol),
+    tokenDecimals: (tokenParams.decimals),
     tokenDataRetrieved: true,
   })
 }

--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -606,8 +606,8 @@ PendingTx.prototype.componentWillUnmount = function () {
 PendingTx.prototype.updateTokenInfo = async function (txParams) {
   const tokenParams = await this.tokenInfoGetter(txParams.to)
   this.setState({
-    tokenSymbol: (tokenParams.symbol),
-    tokenDecimals: (tokenParams.decimals),
+    tokenSymbol: tokenParams.symbol,
+    tokenDecimals: tokenParams.decimals,
     tokenDataRetrieved: true,
   })
 }

--- a/ui/app/token-util.js
+++ b/ui/app/token-util.js
@@ -26,24 +26,32 @@ const DEFAULT_DECIMALS = '0'
 async function getSymbolFromContract (tokenAddress) {
   const token = util.getContractAtAddress(tokenAddress)
 
-  try {
-    const result = await token.symbol()
-    return result[0]
-  } catch (error) {
-    log.warn(`symbol() call for token at address ${tokenAddress} resulted in error:`, error)
+  if (token.bytecode !== '0x') {
+    try {
+      const result = await token.symbol()
+      return result[0]
+    } catch (error) {
+      log.warn(`symbol() call for token at address ${tokenAddress} resulted in error:`, error)
+      return ''
+    }
   }
+  return ''
 }
 
 async function getDecimalsFromContract (tokenAddress) {
   const token = util.getContractAtAddress(tokenAddress)
 
-  try {
-    const result = await token.decimals()
-    const decimalsBN = result[0]
-    return decimalsBN && decimalsBN.toString()
-  } catch (error) {
-    log.warn(`decimals() call for token at address ${tokenAddress} resulted in error:`, error)
+  if (token.bytecode !== '0x') {
+    try {
+      const result = await token.decimals()
+      const decimalsBN = result[0]
+      return decimalsBN && decimalsBN.toString()
+    } catch (error) {
+      log.warn(`decimals() call for token at address ${tokenAddress} resulted in error:`, error)
+      return '0'
+    }
   }
+  return '0'
 }
 
 function getContractMetadata (tokenAddress) {

--- a/ui/app/token-util.js
+++ b/ui/app/token-util.js
@@ -26,32 +26,24 @@ const DEFAULT_DECIMALS = '0'
 async function getSymbolFromContract (tokenAddress) {
   const token = util.getContractAtAddress(tokenAddress)
 
-  if (token.bytecode !== '0x') {
-    try {
-      const result = await token.symbol()
-      return result[0]
-    } catch (error) {
-      log.warn(`symbol() call for token at address ${tokenAddress} resulted in error:`, error)
-      return ''
-    }
+  try {
+    const result = await token.symbol()
+    return result[0]
+  } catch (error) {
+    log.warn(`symbol() call for token at address ${tokenAddress} resulted in error:`, error)
   }
-  return ''
 }
 
 async function getDecimalsFromContract (tokenAddress) {
   const token = util.getContractAtAddress(tokenAddress)
 
-  if (token.bytecode !== '0x') {
-    try {
-      const result = await token.decimals()
-      const decimalsBN = result[0]
-      return decimalsBN && decimalsBN.toString()
-    } catch (error) {
-      log.warn(`decimals() call for token at address ${tokenAddress} resulted in error:`, error)
-      return '0'
-    }
+  try {
+    const result = await token.decimals()
+    const decimalsBN = result[0]
+    return decimalsBN && decimalsBN.toString()
+  } catch (error) {
+    log.warn(`decimals() call for token at address ${tokenAddress} resulted in error:`, error)
   }
-  return '0'
 }
 
 function getContractMetadata (tokenAddress) {


### PR DESCRIPTION
We should create a request to get token's symbol and decimals, only for token transfer.
For now, it tries to get token's metadata for any type of pending tx, thereby, sometimes, it causes a white screen for pending tx page.

Also, MM warning about EIP-1102 implementation is removed.

@dennis00010011b @fvictorio @patitonar please take a look.

Should be merged to master and released as soon as possible.