### PR TITLE
(Feature) Reorder contract executors: owners are first

### DIFF
--- a/old-ui/app/components/send/choose-contract-executor.js
+++ b/old-ui/app/components/send/choose-contract-executor.js
@@ -7,13 +7,46 @@ import SendHeader from './send-header'
 import SendError from './send-error'
 import actions from '../../../../ui/app/actions'
 import { ifContractAcc } from '../../util'
+import Web3 from 'web3'
+
+const ownerABI = [{
+	"constant": true,
+	"inputs": [],
+	"name": "owner",
+	"outputs": [
+		{
+			"name": "",
+			"type": "address"
+		}
+	],
+	"payable": false,
+	"type": "function",
+	"stateMutability": "view"
+}]
+
+const getOwnersABI = [{
+	"constant": true,
+	"inputs": [],
+	"name": "getOwners",
+	"outputs": [
+		{
+			"name": "",
+			"type": "address[]"
+		}
+	],
+	"payable": false,
+	"type": "function",
+	"stateMutability": "view"
+}]
 
 class ChooseContractExecutor extends Component {
 	constructor (props) {
 		super(props)
 		this.state = {
+			web3: new Web3(global.ethereumProvider),
 			selectedExecutor: '',
 			accountsCells: [],
+			owners: [],
 			nextDisabled: true,
 		}
 	}
@@ -61,7 +94,8 @@ class ChooseContractExecutor extends Component {
 		)
 	}
 
-	componentDidMount () {
+	componentDidMount = async () => {
+		await this.getAllOwners()
 		this.generateListOfAccounts()
 	}
 
@@ -88,28 +122,69 @@ class ChooseContractExecutor extends Component {
 		return buttonContainer
 	}
 
-	generateListOfAccounts () {
+	generateListOfAccounts = () => {
 		const { keyrings, identities } = this.props
 		const accountsCells = []
 		keyrings.forEach((keyring) => {
 			if (!ifContractAcc(keyring)) {
 				keyring.accounts.forEach((address) => {
 					const identity = identities[address]
-					accountsCells.push(
-						<ExecutorCell
-							key={Math.random()}
-							address={address}
-							identity={identity}
-							isAccountSelected={this.isAccountSelected(address)}
-							onClick={(e, isSelected) => this.selectExecutor(e, isSelected, address)}
-						/>
-					)
+					const executorCell = <ExecutorCell
+						key={Math.random()}
+						address={address}
+						identity={identity}
+						isAccountSelected={this.isAccountSelected(address)}
+						onClick={(e, isSelected) => this.selectExecutor(e, isSelected, address)}
+					/>
+					if (this.state.owners.includes(address)) {
+						accountsCells.unshift(executorCell)
+					} else {
+						accountsCells.push(executorCell)
+					}
 				})
 			}
 		})
 
 		this.setState({
 			accountsCells,
+		})
+	}
+
+	getAllOwners = () => {
+		this.props.showLoadingIndication()
+		return new Promise((resolve) => {
+			Promise.all([this.getOwner(), this.getOwners()])
+			.then(([owner, owners]) => {
+				if (owner !== '0x' && !owners.includes(owner)) {
+					owners.push(owner)
+				}
+				this.setState({ owners })
+				this.props.hideLoadingIndication()
+				resolve()
+			})
+		})
+	}
+
+	getOwner = () => {
+		return this.getOwnersCommon('owner', ownerABI)
+	}
+
+	getOwners = () => {
+		return this.getOwnersCommon('getOwners', getOwnersABI)
+	}
+
+	getOwnersCommon = (method, abi) => {
+		const { web3 } = this.state
+		const { txParams } = this.props
+
+		return new Promise((resolve) => {
+			try {
+				web3.eth.contract(abi).at(txParams.to)[method].call((err, output) => {
+					resolve(output)
+				})
+			} catch (e) {
+				resolve('')
+			}
 		})
 	}
 
@@ -170,6 +245,8 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps (dispatch) {
 	return {
+		showLoadingIndication: () => dispatch(actions.showLoadingIndication()),
+		hideLoadingIndication: () => dispatch(actions.hideLoadingIndication()),
 		hideWarning: () => dispatch(actions.hideWarning()),
 		signTx: (txParams) => dispatch(actions.signTx(txParams)),
 		setSelectedAddress: (address) => dispatch(actions.setSelectedAddress(address)),

--- a/old-ui/app/components/send/choose-contract-executor.js
+++ b/old-ui/app/components/send/choose-contract-executor.js
@@ -10,33 +10,33 @@ import { ifContractAcc } from '../../util'
 import Web3 from 'web3'
 
 const ownerABI = [{
-	"constant": true,
-	"inputs": [],
-	"name": "owner",
-	"outputs": [
+	'constant': true,
+	'inputs': [],
+	'name': 'owner',
+	'outputs': [
 		{
-			"name": "",
-			"type": "address"
-		}
+			'name': '',
+			'type': 'address',
+		},
 	],
-	"payable": false,
-	"type": "function",
-	"stateMutability": "view"
+	'payable': false,
+	'type': 'function',
+	'stateMutability': 'view',
 }]
 
 const getOwnersABI = [{
-	"constant": true,
-	"inputs": [],
-	"name": "getOwners",
-	"outputs": [
+	'constant': true,
+	'inputs': [],
+	'name': 'getOwners',
+	'outputs': [
 		{
-			"name": "",
-			"type": "address[]"
-		}
+			'name': '',
+			'type': 'address[]',
+		},
 	],
-	"payable": false,
-	"type": "function",
-	"stateMutability": "view"
+	'payable': false,
+	'type': 'function',
+	'stateMutability': 'view',
 }]
 
 class ChooseContractExecutor extends Component {
@@ -63,6 +63,8 @@ class ChooseContractExecutor extends Component {
 		identities: PropTypes.object,
 		keyrings: PropTypes.array,
 		error: PropTypes.string,
+		showLoadingIndication: PropTypes.func,
+		hideLoadingIndication: PropTypes.func,
 	}
 
 	render () {

--- a/test/unit/old-ui/app/components/send/choose-contract-executor.spec.js
+++ b/test/unit/old-ui/app/components/send/choose-contract-executor.spec.js
@@ -73,8 +73,14 @@ describe('ChooseContractExecutor component', () => {
 			assert.equal(wrapper.find('.choose-contract-next-button').text(), 'Next')
 		})
 
-		it('the number of accounts is equal to number of keyrings', () => {
-			assert.equal(wrapper.find('.executor-cell-container').length, state.metamask.keyrings.length)
+		it('the number of accounts is equal to number of keyrings', async () => {
+			return new Promise(resolve => {
+				setTimeout(() => {
+					wrapper.update()
+					assert.equal(wrapper.find('.executor-cell-container').length, state.metamask.keyrings.length)
+					resolve()
+				}, 500)
+			})
 		})
 	})
 })


### PR DESCRIPTION
If an executed contract has `owner` or `getOwners` getters, and addresses from the resulted array are in the list of wallet accounts, they will be first in the list in the *Choose contract executor
* screen.