### PR TITLE
e2e for change-to-contract-acc-after-execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3505,7 +3505,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-from": {
@@ -5462,7 +5462,7 @@
     },
     "brfs": {
       "version": "1.6.1",
-      "resolved": "http://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
       "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
       "dev": true,
       "requires": {
@@ -5546,7 +5546,7 @@
       "dependencies": {
         "resolve": {
           "version": "1.1.7",
-          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
           "dev": true
         }
@@ -6828,7 +6828,7 @@
     },
     "color-string": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "requires": {
         "color-name": "^1.0.0"
@@ -7169,7 +7169,7 @@
     },
     "content-disposition": {
       "version": "0.5.2",
-      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
@@ -7572,7 +7572,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
@@ -7652,7 +7652,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -8147,7 +8147,7 @@
     },
     "deps-sort": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
@@ -8780,7 +8780,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
@@ -10104,7 +10104,7 @@
       }
     },
     "eth-contract-metadata": {
-      "version": "github:MetaMask/eth-contract-metadata#889defeaaa18e5488f2695a462d22a29936229e2",
+      "version": "github:MetaMask/eth-contract-metadata#05e39ee1be2edaa53b04ff7e215cdd6db16d09c1",
       "from": "github:MetaMask/eth-contract-metadata#master"
     },
     "eth-ens-namehash": {
@@ -10205,12 +10205,13 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^5.0.0"
@@ -10473,12 +10474,13 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^5.0.0"
@@ -11195,12 +11197,13 @@
               "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "requires": {
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
                 "ethereumjs-util": "^5.1.1"
               },
               "dependencies": {
                 "ethereumjs-abi": {
                   "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                   "requires": {
                     "bn.js": "^4.10.0",
                     "ethereumjs-util": "^5.0.0"
@@ -11986,7 +11989,7 @@
         },
         "expand-range": {
           "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
           "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
           "dev": true,
           "requires": {
@@ -12018,7 +12021,7 @@
     },
     "expand-range": {
       "version": "1.8.2",
-      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "requires": {
         "fill-range": "^2.1.0"
@@ -14233,7 +14236,7 @@
         },
         "array-flatten": {
           "version": "1.1.1",
-          "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
           "dev": true
         },
@@ -15012,7 +15015,8 @@
         "bindings": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-          "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
+          "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+          "dev": true
         },
         "bip39": {
           "version": "2.5.0",
@@ -15031,6 +15035,7 @@
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
           "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -15065,7 +15070,8 @@
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "dev": true
         },
         "body-parser": {
           "version": "1.18.3",
@@ -15108,12 +15114,14 @@
         "brorand": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+          "dev": true
         },
         "browserify-aes": {
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+          "dev": true,
           "requires": {
             "buffer-xor": "^1.0.3",
             "cipher-base": "^1.0.0",
@@ -15270,7 +15278,8 @@
         "buffer-xor": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+          "dev": true
         },
         "builtin-modules": {
           "version": "1.1.1",
@@ -15368,6 +15377,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -15527,6 +15537,7 @@
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+          "dev": true,
           "requires": {
             "cipher-base": "^1.0.1",
             "inherits": "^2.0.1",
@@ -15539,6 +15550,7 @@
           "version": "1.1.7",
           "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+          "dev": true,
           "requires": {
             "cipher-base": "^1.0.3",
             "create-hash": "^1.1.0",
@@ -15838,6 +15850,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
           "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+          "dev": true,
           "requires": {
             "browserify-aes": "^1.0.6",
             "create-hash": "^1.1.2",
@@ -15876,6 +15889,7 @@
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
           "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -16166,6 +16180,7 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
                 "ethereumjs-util": "^5.1.1"
               }
             },
@@ -16177,7 +16192,8 @@
             },
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "dev": true,
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^5.0.0"
@@ -16198,7 +16214,7 @@
             },
             "ethereumjs-vm": {
               "version": "2.3.4",
-              "resolved": "http://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
               "integrity": "sha512-Y4SlzNDqxrCO58jhp98HdnZVdjOqB+HC0hoU+N/DEp1aU+hFkRX/nru5F7/HkQRPIlA6aJlQp/xIA6xZs1kspw==",
               "dev": true,
               "requires": {
@@ -16372,6 +16388,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
@@ -16461,6 +16478,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
           "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+          "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0",
             "strip-hex-prefix": "1.0.0"
@@ -16482,6 +16500,7 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+          "dev": true,
           "requires": {
             "md5.js": "^1.3.4",
             "safe-buffer": "^5.1.1"
@@ -16892,6 +16911,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -16901,6 +16921,7 @@
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
           "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.1"
@@ -16928,6 +16949,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+          "dev": true,
           "requires": {
             "hash.js": "^1.0.3",
             "minimalistic-assert": "^1.0.0",
@@ -17095,7 +17117,8 @@
         "is-hex-prefixed": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
+          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
+          "dev": true
         },
         "is-natural-number": {
           "version": "4.0.1",
@@ -17149,7 +17172,8 @@
         "is-typedarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+          "dev": true
         },
         "is-utf8": {
           "version": "0.2.1",
@@ -17295,6 +17319,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
           "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "inherits": "^2.0.3",
@@ -17558,7 +17583,7 @@
         },
         "lru-cache": {
           "version": "3.2.0",
-          "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
           "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
           "dev": true,
           "requires": {
@@ -17594,6 +17619,7 @@
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
           "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+          "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1",
@@ -17753,12 +17779,14 @@
         "minimalistic-assert": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+          "dev": true
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -17810,7 +17838,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "mz": {
           "version": "2.7.0",
@@ -17827,7 +17856,8 @@
         "nan": {
           "version": "2.10.0",
           "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+          "dev": true
         },
         "nano-json-stream-parser": {
           "version": "0.1.2",
@@ -18351,7 +18381,7 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
@@ -18385,7 +18415,7 @@
         },
         "regexpu-core": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "dev": true,
           "requires": {
@@ -18402,7 +18432,7 @@
         },
         "regjsparser": {
           "version": "0.1.5",
-          "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
@@ -18466,7 +18496,7 @@
         },
         "resolve": {
           "version": "1.7.1",
-          "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
           "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
           "dev": true,
           "requires": {
@@ -18494,6 +18524,7 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
           "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+          "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1"
@@ -18503,6 +18534,7 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
           "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
+          "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1"
           }
@@ -18516,7 +18548,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         },
         "safe-event-emitter": {
           "version": "1.0.1",
@@ -18568,6 +18601,7 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.2.tgz",
           "integrity": "sha512-iin3kojdybY6NArd+UFsoTuapOF7bnJNf2UbcWXaY3z+E1sJDipl60vtzB5hbO/uquBu7z0fd4VC4Irp+xoFVQ==",
+          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "bip66": "^1.1.3",
@@ -18699,6 +18733,7 @@
           "version": "2.4.11",
           "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -18873,7 +18908,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
@@ -18909,6 +18944,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
           "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
+          "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0"
           }
@@ -19152,6 +19188,7 @@
           "version": "3.1.5",
           "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
           "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+          "dev": true,
           "requires": {
             "is-typedarray": "^1.0.0"
           }
@@ -19224,7 +19261,7 @@
         },
         "underscore": {
           "version": "1.8.3",
-          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
           "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
           "dev": true
         },
@@ -19594,12 +19631,14 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
                 "ethereumjs-util": "^5.1.1"
               }
             },
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "dev": true,
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^5.0.0"
@@ -19644,20 +19683,23 @@
           "dev": true,
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.35"
+            "web3-core-helpers": "1.0.0-beta.35",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
           },
           "dependencies": {
             "debug": {
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "websocket": {
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+              "dev": true,
               "requires": {
                 "debug": "^2.2.0",
                 "nan": "^2.3.3",
@@ -19836,7 +19878,8 @@
         "yaeti": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-          "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+          "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+          "dev": true
         },
         "yargs": {
           "version": "4.8.1",
@@ -24802,7 +24845,7 @@
         },
         "stream-combiner": {
           "version": "0.2.2",
-          "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
           "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
           "dev": true,
           "requires": {
@@ -24812,7 +24855,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
@@ -25029,7 +25072,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -25486,7 +25529,7 @@
     },
     "karma-cli": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/karma-cli/-/karma-cli-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/karma-cli/-/karma-cli-1.0.1.tgz",
       "integrity": "sha1-rmw8WKMTodALRRZMRVubhs4X+WA=",
       "dev": true,
       "requires": {
@@ -25664,7 +25707,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
@@ -25736,7 +25779,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -25773,7 +25816,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "xtend": {
@@ -26547,7 +26590,7 @@
     },
     "map-stream": {
       "version": "0.1.0",
-      "resolved": "http://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
@@ -27623,7 +27666,7 @@
       "dependencies": {
         "detective": {
           "version": "5.1.0",
-          "resolved": "http://registry.npmjs.org/detective/-/detective-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/detective/-/detective-5.1.0.tgz",
           "integrity": "sha512-TFHMqfOvxlgrfVzTEkNBSh9SvSNX/HfF4OFI2QFGCyPm02EsyILqnUeb5P6q7JZ3SFNTBL5t2sePRgrN4epUWQ==",
           "dev": true,
           "requires": {
@@ -27714,7 +27757,7 @@
     },
     "multimatch": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
@@ -27726,7 +27769,7 @@
     },
     "multipipe": {
       "version": "0.1.2",
-      "resolved": "http://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
       "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
       "dev": true,
       "requires": {
@@ -30229,7 +30272,7 @@
     },
     "path-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
       "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
     },
     "path-dirname": {
@@ -32627,7 +32670,7 @@
         },
         "global-modules": {
           "version": "0.2.3",
-          "resolved": "http://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
           "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
           "dev": true,
           "requires": {
@@ -32637,7 +32680,7 @@
         },
         "global-prefix": {
           "version": "0.1.5",
-          "resolved": "http://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
           "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
           "dev": true,
           "requires": {
@@ -32664,7 +32707,7 @@
         },
         "resolve-dir": {
           "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
           "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
           "dev": true,
           "requires": {
@@ -33742,7 +33785,7 @@
     },
     "regjsparser": {
       "version": "0.1.5",
-      "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "requires": {
         "jsesc": "~0.5.0"
@@ -34058,7 +34101,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
@@ -36128,7 +36171,7 @@
     },
     "split2": {
       "version": "0.2.1",
-      "resolved": "http://registry.npmjs.org/split2/-/split2-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz",
       "integrity": "sha1-At2smtwD7Au3jBKC7Aecpuha6QA=",
       "dev": true,
       "requires": {
@@ -36155,7 +36198,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
@@ -36173,7 +36216,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -36444,7 +36487,7 @@
     },
     "stream-combiner": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
       "dev": true,
       "requires": {
@@ -36569,7 +36612,7 @@
     },
     "string-width": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
         "code-point-at": "^1.0.0",
@@ -37409,7 +37452,7 @@
     },
     "syntax-error": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
       "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
       "dev": true,
       "requires": {
@@ -38202,7 +38245,7 @@
     },
     "tty-browserify": {
       "version": "0.0.0",
-      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
       "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
     },
     "tunnel-agent": {
@@ -38446,7 +38489,7 @@
       "dependencies": {
         "underscore": {
           "version": "1.6.0",
-          "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
           "dev": true
         }
@@ -38504,7 +38547,7 @@
     },
     "union": {
       "version": "0.4.6",
-      "resolved": "http://registry.npmjs.org/union/-/union-0.4.6.tgz",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.4.6.tgz",
       "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
       "dev": true,
       "requires": {
@@ -38513,7 +38556,7 @@
       "dependencies": {
         "qs": {
           "version": "2.3.3",
-          "resolved": "http://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
           "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=",
           "dev": true
         }
@@ -39148,7 +39191,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "requires": {
         "indexof": "0.0.1"
@@ -39167,7 +39210,7 @@
     },
     "walk-sync": {
       "version": "0.3.1",
-      "resolved": "http://registry.npmjs.org/walk-sync/-/walk-sync-0.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.1.tgz",
       "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
       "dev": true,
       "requires": {
@@ -39185,7 +39228,7 @@
     },
     "watchify": {
       "version": "3.11.0",
-      "resolved": "http://registry.npmjs.org/watchify/-/watchify-3.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/watchify/-/watchify-3.11.0.tgz",
       "integrity": "sha512-7jWG0c3cKKm2hKScnSAMUEUjRJKXUShwMPk0ASVhICycQhwND3IMAdhJYmc1mxxKzBUJTSF5HZizfrKrS6BzkA==",
       "dev": true,
       "requires": {
@@ -39232,6 +39275,7 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.3.tgz",
       "integrity": "sha1-yqRDc9yIFayHZ73ba6cwc5ZMqos=",
       "requires": {
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",
@@ -39240,7 +39284,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
         }
       }
     },
@@ -40302,7 +40346,7 @@
     },
     "winston": {
       "version": "2.1.1",
-      "resolved": "http://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.1.1.tgz",
       "integrity": "sha1-PJNJ0ZYgf9G9/51LxD73JRDjoS4=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10205,13 +10205,12 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^5.0.0"
@@ -10474,13 +10473,12 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
               "requires": {
                 "bn.js": "^4.10.0",
                 "ethereumjs-util": "^5.0.0"
@@ -10541,8 +10539,17 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
+              }
+            }
           }
         },
         "ethereum-common": {
@@ -10964,8 +10971,17 @@
           "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
           "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
           "requires": {
-            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
             "ethereumjs-util": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
+              }
+            }
           }
         },
         "ethereum-common": {
@@ -11179,13 +11195,12 @@
               "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
                 "ethereumjs-util": "^5.1.1"
               },
               "dependencies": {
                 "ethereumjs-abi": {
                   "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
                   "requires": {
                     "bn.js": "^4.10.0",
                     "ethereumjs-util": "^5.0.0"
@@ -14997,8 +15012,7 @@
         "bindings": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-          "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-          "dev": true
+          "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
         },
         "bip39": {
           "version": "2.5.0",
@@ -15017,7 +15031,6 @@
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
           "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
-          "dev": true,
           "requires": {
             "safe-buffer": "^5.0.1"
           }
@@ -15052,8 +15065,7 @@
         "bn.js": {
           "version": "4.11.8",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-          "dev": true
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
         },
         "body-parser": {
           "version": "1.18.3",
@@ -15096,14 +15108,12 @@
         "brorand": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-          "dev": true
+          "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "browserify-aes": {
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-          "dev": true,
           "requires": {
             "buffer-xor": "^1.0.3",
             "cipher-base": "^1.0.0",
@@ -15260,8 +15270,7 @@
         "buffer-xor": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-          "dev": true
+          "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
         },
         "builtin-modules": {
           "version": "1.1.1",
@@ -15359,7 +15368,6 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -15519,7 +15527,6 @@
           "version": "1.2.0",
           "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-          "dev": true,
           "requires": {
             "cipher-base": "^1.0.1",
             "inherits": "^2.0.1",
@@ -15532,7 +15539,6 @@
           "version": "1.1.7",
           "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-          "dev": true,
           "requires": {
             "cipher-base": "^1.0.3",
             "create-hash": "^1.1.0",
@@ -15832,7 +15838,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
           "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-          "dev": true,
           "requires": {
             "browserify-aes": "^1.0.6",
             "create-hash": "^1.1.2",
@@ -15871,7 +15876,6 @@
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
           "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
-          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -16162,19 +16166,7 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
                 "ethereumjs-util": "^5.1.1"
-              },
-              "dependencies": {
-                "ethereumjs-abi": {
-                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-                  "dev": true,
-                  "requires": {
-                    "bn.js": "^4.10.0",
-                    "ethereumjs-util": "^5.0.0"
-                  }
-                }
               }
             },
             "ethereum-common": {
@@ -16182,6 +16174,14 @@
               "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
               "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA==",
               "dev": true
+            },
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
+              }
             },
             "ethereumjs-block": {
               "version": "1.7.1",
@@ -16372,7 +16372,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
-          "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
@@ -16462,7 +16461,6 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
           "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-          "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0",
             "strip-hex-prefix": "1.0.0"
@@ -16484,7 +16482,6 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-          "dev": true,
           "requires": {
             "md5.js": "^1.3.4",
             "safe-buffer": "^5.1.1"
@@ -16895,7 +16892,6 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -16905,7 +16901,6 @@
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.5.tgz",
           "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.1"
@@ -16933,7 +16928,6 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-          "dev": true,
           "requires": {
             "hash.js": "^1.0.3",
             "minimalistic-assert": "^1.0.0",
@@ -17101,8 +17095,7 @@
         "is-hex-prefixed": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
-          "dev": true
+          "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
         },
         "is-natural-number": {
           "version": "4.0.1",
@@ -17156,8 +17149,7 @@
         "is-typedarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-          "dev": true
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "is-utf8": {
           "version": "0.2.1",
@@ -17303,7 +17295,6 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
           "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "inherits": "^2.0.3",
@@ -17603,7 +17594,6 @@
           "version": "1.3.5",
           "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
           "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-          "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1",
@@ -17763,14 +17753,12 @@
         "minimalistic-assert": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-          "dev": true
+          "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
         },
         "minimalistic-crypto-utils": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-          "dev": true
+          "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "minimatch": {
           "version": "3.0.4",
@@ -17822,8 +17810,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "mz": {
           "version": "2.7.0",
@@ -17840,8 +17827,7 @@
         "nan": {
           "version": "2.10.0",
           "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
-          "dev": true
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
         },
         "nano-json-stream-parser": {
           "version": "0.1.2",
@@ -18508,7 +18494,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
           "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-          "dev": true,
           "requires": {
             "hash-base": "^3.0.0",
             "inherits": "^2.0.1"
@@ -18518,7 +18503,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.1.0.tgz",
           "integrity": "sha512-93U7IKH5j7nmXFVg19MeNBGzQW5uXW1pmCuKY8veeKIhYTE32C2d0mOegfiIAfXcHOKJjjPlJisn8iHDF5AezA==",
-          "dev": true,
           "requires": {
             "safe-buffer": "^5.1.1"
           }
@@ -18532,8 +18516,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safe-event-emitter": {
           "version": "1.0.1",
@@ -18585,7 +18568,6 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.2.tgz",
           "integrity": "sha512-iin3kojdybY6NArd+UFsoTuapOF7bnJNf2UbcWXaY3z+E1sJDipl60vtzB5hbO/uquBu7z0fd4VC4Irp+xoFVQ==",
-          "dev": true,
           "requires": {
             "bindings": "^1.2.1",
             "bip66": "^1.1.3",
@@ -18717,7 +18699,6 @@
           "version": "2.4.11",
           "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "safe-buffer": "^5.0.1"
@@ -18928,7 +18909,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
           "integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
-          "dev": true,
           "requires": {
             "is-hex-prefixed": "1.0.0"
           }
@@ -19172,7 +19152,6 @@
           "version": "3.1.5",
           "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
           "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-          "dev": true,
           "requires": {
             "is-typedarray": "^1.0.0"
           }
@@ -19615,19 +19594,15 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
                 "ethereumjs-util": "^5.1.1"
-              },
-              "dependencies": {
-                "ethereumjs-abi": {
-                  "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
-                  "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-                  "dev": true,
-                  "requires": {
-                    "bn.js": "^4.10.0",
-                    "ethereumjs-util": "^5.0.0"
-                  }
-                }
+              }
+            },
+            "ethereumjs-abi": {
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#2863c40e0982acfc0b7163f0285d4c56427c7799",
+              "requires": {
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
               }
             },
             "ws": {
@@ -19669,23 +19644,20 @@
           "dev": true,
           "requires": {
             "underscore": "1.8.3",
-            "web3-core-helpers": "1.0.0-beta.35",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+            "web3-core-helpers": "1.0.0-beta.35"
           },
           "dependencies": {
             "debug": {
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
             },
             "websocket": {
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-              "dev": true,
+              "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
               "requires": {
                 "debug": "^2.2.0",
                 "nan": "^2.3.3",
@@ -19864,8 +19836,7 @@
         "yaeti": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-          "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
-          "dev": true
+          "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
         },
         "yargs": {
           "version": "4.8.1",
@@ -39261,7 +39232,6 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.3.tgz",
       "integrity": "sha1-yqRDc9yIFayHZ73ba6cwc5ZMqos=",
       "requires": {
-        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",
@@ -39270,7 +39240,7 @@
       "dependencies": {
         "bignumber.js": {
           "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+          "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
         }
       }
     },

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -2,6 +2,7 @@ const webdriver = require('selenium-webdriver')
 const { By } = webdriver
 module.exports = {
   elements: {
+    buttonArrow: By.className('fa fa-arrow-left fa-lg cursor-pointer'),
     errorClose: By.css('.send-screen > div:nth-child(3) > div:nth-child(1)'),
     error: By.className('error'),
     loader: By.css('#app-content > div > div.full-flex-height > img'),
@@ -73,7 +74,7 @@ module.exports = {
       buttonNext: By.css('.section > div:nth-child(1) > button:nth-child(2)'),
       buttonArrow: By.className('fa fa-arrow-left fa-lg cursor-pointer'),
       buttonCopyABI: By.className('btn-violet'),
-      buttonExecuteMethod: By.css('#app-content > div > div.app-primary.from-right > div > div > div.flex-row > button'),
+      buttonExecuteMethod: By.xpath('//*[@id="app-content"]/div/div[2]/div/div/div[2]/button')
     },
     eventsEmitter: {
       button: By.className('btn btn-default'),
@@ -233,7 +234,7 @@ module.exports = {
       error: By.css('span.error'),
       selectArrow: By.className('Select-arrow-zone'),
       selectType: By.name('import-type-select'),
-      itemContract: By.id('react-select-2--option-2'),
+      itemContract: By.id('react-select-3--option-2'),
       contractAddress: By.id('address-box'),
       contractABI: By.id('abi-box'),
       title: By.css('#app-content > div > div.app-primary.from-right > div > div:nth-child(2) > div.flex-row.flex-center > h2'),
@@ -265,6 +266,7 @@ module.exports = {
       },
     },
     main: {
+      accountAddress:By.xpath("//*[@id=\"app-content\"]/div/div[2]/div/div/div[1]/flex-column/div[2]/div/span"),
       identicon: By.className('identicon-wrapper select-none'),
       fieldAccountName: By.className('sizing-input'),
       accountName: By.className('font-medium color-forest'),

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -33,12 +33,14 @@ module.exports = {
       account1: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(2) > span'),
       account2: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(3) > span'),
       account3: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(4) > span'),
+      account4: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(5) > span'),
       menu: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div'),
-      delete: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(4) > div.remove'),
+      delete: By.className('remove'),
       createAccount: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(3) > span'),
       // import: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(5) > span'),
       import: By.css('li.dropdown-menu-item:nth-child(5) > span:nth-child(1)'),
-      labelImported: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(4) > div.keyring-label'),
+      import2: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(6)'),
+      label: By.className('keyring-label'),
     },
     dot: {
       menu: By.className('account-dropdown'),
@@ -75,7 +77,7 @@ module.exports = {
       buttonNext: By.css('.section > div:nth-child(1) > button:nth-child(2)'),
       buttonArrow: By.className('fa fa-arrow-left fa-lg cursor-pointer'),
       buttonCopyABI: By.className('btn-violet'),
-      buttonExecuteMethod: By.xpath('//*[@id="app-content"]/div/div[2]/div/div/div[2]/button')
+      buttonExecuteMethod: By.xpath('//*[@id="app-content"]/div/div[2]/div/div/div[2]/button'),
     },
     eventsEmitter: {
       button: By.className('btn btn-default'),
@@ -197,7 +199,8 @@ module.exports = {
       button: {
         submit: By.css('#pending-tx-form > div.flex-row.flex-space-around.conf-buttons > input'),
         reject: By.css('.cancel'),
-        rejectAll: By.css('#pending-tx-form > div:nth-child(4) > button')
+        rejectAll: By.css('#pending-tx-form > div:nth-child(4) > button'),
+        buyEther: By.css('#pending-tx-form > div.flex-row.flex-space-around.conf-buttons > button.btn-green'),
       },
       fields: {
         gasLimit: By.css('#pending-tx-form > div:nth-child(1) > div.table-box > div:nth-child(3) > div.cell.value > div > div > input'),
@@ -268,7 +271,7 @@ module.exports = {
       },
     },
     main: {
-      accountAddress:By.xpath("//*[@id=\"app-content\"]/div/div[2]/div/div/div[1]/flex-column/div[2]/div/span"),
+      accountAddress: By.xpath('//*[@id="app-content"]/div/div[2]/div/div/div[1]/flex-column/div[2]/div/span'),
       identicon: By.className('identicon-wrapper select-none'),
       fieldAccountName: By.className('sizing-input'),
       accountName: By.className('font-medium color-forest'),
@@ -301,6 +304,9 @@ module.exports = {
         counter: By.css('#app-content > div > div.app-primary.from-left > div > section > div.full-flex-height > div > span'),
         counterFF: By.css('div.full-flex-height:nth-child(2) > div:nth-child(1) > span:nth-child(1)'),
       },
+    },
+    buyEther: {
+      title: By.className('flex-center buy-title'),
     },
     info: {
       title: By.className('section-title flex-row flex-center'),

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -32,6 +32,7 @@ module.exports = {
     account: {
       account1: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(2) > span'),
       account2: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(3) > span'),
+      account3: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(4) > span'),
       menu: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div'),
       delete: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(4) > div.remove'),
       createAccount: By.css('#app-content > div > div.full-width > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(3) > span'),
@@ -196,6 +197,7 @@ module.exports = {
       button: {
         submit: By.css('#pending-tx-form > div.flex-row.flex-space-around.conf-buttons > input'),
         reject: By.css('.cancel'),
+        rejectAll: By.css('#pending-tx-form > div:nth-child(4) > button')
       },
       fields: {
         gasLimit: By.css('#pending-tx-form > div:nth-child(1) > div.table-box > div:nth-child(3) > div.cell.value > div > div > input'),

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -11,11 +11,11 @@ const { menus, screens, elements, NETWORKS } = require('./elements')
 const testSeedPhrase = 'horn among position unable audit puzzle cannon apology gun autumn plug parrot'
 const account1 = '0x2E428ABd9313D256d64D1f69fe3929C3BE18fD1f'
 const account2 = '0xd7b7AFeCa35e32594e29504771aC847E2a803742'
-const createdAccounts =[]
+const createdAccounts = []
 const eventsEmitter = 'https://vbaranov.github.io/event-listener-dapp/'
 
 describe('Metamask popup page', async function () {
-  let driver, accountAddress, tokenAddress, extensionId
+  let driver, tokenAddress, extensionId
   let password = '123456789'
   const newPassword = {
     correct: 'abcDEF123!@#',
@@ -256,7 +256,7 @@ describe('Metamask popup page', async function () {
   })
   describe('Import Account', () => {
 
-    it('opens import account menu', async function () {
+    it('Open import account menu', async function () {
       await setProvider(NETWORKS.POA)
       await delay(2000)
       const menu = await waitUntilShowUp(menus.account.menu)
@@ -267,7 +267,7 @@ describe('Metamask popup page', async function () {
       assert.equal(await importAccountTitle.getText(), screens.importAccounts.textTitle)
     })
 
-    it('imports account', async function () {
+    it('Imports account', async function () {
       const privateKeyBox = await waitUntilShowUp(screens.importAccounts.fieldPrivateKey)
       await privateKeyBox.sendKeys('76bd0ced0a47055bb5d060e1ae4a8cb3ece658d668823e250dae6e79d3ab4435')// 0xf4702CbA917260b2D6731Aea6385215073e8551b
       const button = await waitUntilShowUp(screens.importAccounts.buttonImport)
@@ -275,8 +275,8 @@ describe('Metamask popup page', async function () {
       assert.equal(await button.getText(), 'Import', 'button has incorrect name')
       const menu = await waitUntilShowUp(menus.account.menu)
       await menu.click()
-      await waitUntilShowUp(menus.account.labelImported)
-      const label = (await driver.findElements(menus.account.labelImported))[0]
+      await waitUntilShowUp(menus.account.label)
+      const label = (await driver.findElements(menus.account.label))[0]
       assert.equal(await label.getText(), 'IMPORTED')
       await menu.click()
     })
@@ -298,46 +298,15 @@ describe('Metamask popup page', async function () {
       console.log(await balance.getText())
       assert.equal(await balance.getText(), '0.001 WETH', 'token isnt\' auto-detected')
     })
-    it('opens delete imported account screen', async function () {
-      const menu = await waitUntilShowUp(menus.account.menu)
-      await menu.click()
-      const item = await waitUntilShowUp(menus.account.delete)
-      await item.click()
-      const deleteImportedAccountTitle = await waitUntilShowUp(screens.deleteImportedAccount.title)
-      assert.equal(await deleteImportedAccountTitle.getText(), screens.deleteImportedAccount.titleText)
-    })
 
-    it('doesn\'t remove imported account with \'No\' button', async function () {
-      const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.no)
-      assert.equal(await button.getText(), 'No', 'button has incorrect name')
-      await click(button)
-      const settingsTitle = await waitUntilShowUp(screens.settings.title)
-      assert.equal(await settingsTitle.getText(), 'Settings')
-      // check, that imported account still exists
-      const menu = await waitUntilShowUp(menus.account.menu)
-      await menu.click()
-      const importedLabel = await waitUntilShowUp(menus.account.labelImported)
-      assert.equal(await importedLabel.getText(), 'IMPORTED')
-    })
-
-    it('opens delete imported account screen again', async function () {
-      const menu = await waitUntilShowUp(menus.account.delete)
-      await menu.click()
-    })
-
-    it('removes imported account with \'Yes\' button', async function () {
-      const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.yes)
-      assert.equal(await button.getText(), 'Yes', 'button has incorrect name')
-      await click(button)
-      const settingsTitle = await waitUntilShowUp(screens.settings.title)
-      assert.equal(await settingsTitle.getText(), 'Settings')
-      // check, that imported account is removed
-      const menu = await waitUntilShowUp(menus.account.menu)
-      await menu.click()
-      await waitUntilShowUp(menus.account.labelImported, 25)
-      const importedAccounts = await driver.findElements(menus.account.labelImported)
-      assert.ok(importedAccounts.length === 0)
-      await menu.click()
+    it('Check Sokol balance', async function () {
+      await setProvider(NETWORKS.POA)
+      await delay(2000)
+      const balanceField = await waitUntilShowUp(screens.main.balance)
+      const balance = await balanceField.getText()
+      console.log('Account = 0xf4702CbA917260b2D6731Aea6385215073e8551b')
+      console.log('Balance = ' + balance)
+      assert.equal(parseFloat(balance) > 0.001, true, 'Balance of account 0xf4702CbA917260b2D6731Aea6385215073e8551b TOO LOW !!! Please refill with Sokol eth!!!!')
     })
 
   })
@@ -353,7 +322,7 @@ describe('Metamask popup page', async function () {
         await setProvider(NETWORKS.ROPSTEN)
         const menu = await waitUntilShowUp(menus.account.menu)
         await menu.click()
-        const item = await waitUntilShowUp(menus.account.import)
+        const item = await waitUntilShowUp(menus.account.import2)
         await item.click()
         const importAccountTitle = await waitUntilShowUp(screens.importAccounts.title)
         assert.equal(await importAccountTitle.getText(), screens.importAccounts.textTitle)
@@ -531,9 +500,9 @@ describe('Metamask popup page', async function () {
         const stringValue = 'POA network'
 
         it("Select method 'returnString'", async function () {
+          await delay(2000)
           const field = await waitUntilShowUp(screens.executeMethod.selectArrow)
           await field.click()
-          await delay(2000)
           await waitUntilShowUp(screens.executeMethod.items)
           const list = await driver.findElements(screens.executeMethod.items)
           await list[14].click()
@@ -835,19 +804,18 @@ describe('Metamask popup page', async function () {
     })
     describe('Choose Contract Executor', () => {
 
-      const executor2=  '0xf4702CbA917260b2D6731Aea6385215073e8551b'
-      it('title is displayed and correct', async function () {
+      it('Title is displayed and correct', async function () {
         await delay(5000)
         const title = await waitUntilShowUp(screens.chooseContractExecutor.title)
         assert.notEqual(title, false, 'title isn\'t displayed')
         assert.equal(await title.getText(), screens.chooseContractExecutor.titleText, 'incorrect text')
       })
 
-      it('two accounts displayed', async function () {
+      it('Two accounts displayed', async function () {
         const accs = await waitUntilShowUp(screens.chooseContractExecutor.account)
         assert.notEqual(accs, false, 'accounts aren\'t displayed')
         const accounts = await driver.findElements(screens.chooseContractExecutor.account)
-        assert.equal(accounts.length, 3, "number of accounts isn't 2")
+        assert.equal(accounts.length, 4, "number of accounts isn't 2")
       })
 
       it("Click arrow button leads to 'Execute Method' screen ", async function () {
@@ -896,13 +864,21 @@ describe('Metamask popup page', async function () {
         await delay(3000)
         const reject = await waitUntilShowUp(screens.confirmTransaction.button.reject)
         assert.notEqual(reject, false, "button reject isn't displayed")
+      })
 
+      it("Button 'Buy Ether' is displayed and enabled", async function () {
+        const button = await waitUntilShowUp(screens.confirmTransaction.button.buyEther)
+        await button.click()
+        const title = await waitUntilShowUp(screens.buyEther.title)
+        assert.equal(await title.getText(), 'Buy POA', "screen 'Buy Ether' has incorrect title text")
+        const arrow = await waitUntilShowUp(elements.buttonArrow)
+        await arrow.click()
       })
 
       it("Click button 'Reject' open contract's account screen", async function () {
         const reject = await waitUntilShowUp(screens.confirmTransaction.button.reject)
         await reject.click()
-        //await delay(2000)
+        // await delay(2000)
         const buttonExecute = await waitUntilShowUp(screens.executeMethod.buttonExecuteMethod)
         assert.notEqual(buttonExecute, false, "contract's account hasn't opened")
       })
@@ -914,17 +890,17 @@ describe('Metamask popup page', async function () {
         await arrow.click()
         await delay(2000)
         const address = await waitUntilShowUp(screens.main.address)
-        assert.equal((await address.getText()).toUpperCase(),createdAccounts[0], "executors account isn't opened")
+        assert.equal((await address.getText()).toUpperCase(), createdAccounts[0], "executors account isn't opened")
       })
 
      it('Switch to contract account ', async function () {
         const accountMenu = await waitUntilShowUp(menus.account.menu)
         await accountMenu.click()
-        const item = await waitUntilShowUp(menus.account.account3)
+        const item = await waitUntilShowUp(menus.account.account4)
         await item.click()
         await delay(2000)
         const address = await waitUntilShowUp(screens.main.address)
-        assert.equal((await address.getText()).toUpperCase(),contractSokol.toUpperCase(), "contract's account isn't opened")
+        assert.equal((await address.getText()).toUpperCase(), contractSokol.toUpperCase(), "contract's account isn't opened")
       })
 
       it("Confirm transaction: button 'Reject All' leads to executor's account screen", async function () {
@@ -933,41 +909,30 @@ describe('Metamask popup page', async function () {
         await rejectAll.click()
         await delay(2000)
         const address = await waitUntilShowUp(screens.main.address)
-        assert.equal((await address.getText()).toUpperCase(),contractSokol.toUpperCase(), "executors account isn't opened")
+        assert.equal((await address.getText()).toUpperCase(), contractSokol.toUpperCase(), "executors account isn't opened")
       })
 
       it("Confirm transaction: button 'Submit' leads to executor's account screen", async function () {
-        assert.equal(await executeTransferMethod(1), true, "can't execute the method 'transfer'")
+        assert.equal(await executeTransferMethod(2), true, "can't execute the method 'transfer'")
         await delay(2000)
-        const  button = await waitUntilShowUp(screens.confirmTransaction.button.submit)
+        const button = await waitUntilShowUp(screens.confirmTransaction.button.submit)
         await button.click()
         await delay(2000)
         const address = await waitUntilShowUp(screens.main.address)
-        assert.equal((await address.getText()).toUpperCase(),contractSokol.toUpperCase(), "executors account isn't opened")
+        assert.equal((await address.getText()).toUpperCase(), contractSokol.toUpperCase(), "executors account isn't opened")
       })
 
-
-      it("Stop", async function () {
-        throw("Stop!")
-        const balanceField = await waitUntilShowUp(screens.main.balance)
-        await delay(2000)
-        const balance = await balanceField.getText()
-        console.log('Account = ' + account)
-        console.log('Balance = ' + balance)
-        assert.equal(parseFloat(balance) > 0.001, true, 'Balance of account ' + account + ' TOO LOW !!! Please refill with Sokol eth!!!!')
-
-      })
-
-      it("Label 'CONTRACT' present", async function () {
+     it("Label 'CONTRACT' present", async function () {
         const menu = await waitUntilShowUp(menus.account.menu)
         await menu.click()
-        await waitUntilShowUp(menus.account.labelImported)
-        const label = (await driver.findElements(menus.account.labelImported))[0]
+        await waitUntilShowUp(menus.account.label)
+        const label = (await driver.findElements(menus.account.label))[1]
         assert.equal(await label.getText(), 'CONTRACT', 'label incorrect')
       })
       it('Delete imported account', async function () {
-        const item = await waitUntilShowUp(menus.account.delete)
-        await item.click()
+        await waitUntilShowUp(menus.account.delete)
+        const items = await driver.findElements(menus.account.delete)
+        await items[1].click()
         const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.yes)
         await button.click()
         const buttonArrow = await waitUntilShowUp(screens.settings.buttons.arrow)
@@ -977,10 +942,53 @@ describe('Metamask popup page', async function () {
       })
     })
   })
+  describe('Delete Imported Account', () => {
 
+    it('Open delete imported account screen', async function () {
+      const menu = await waitUntilShowUp(menus.account.menu)
+      await menu.click()
+      const item = await waitUntilShowUp(menus.account.delete)
+      await item.click()
+      const deleteImportedAccountTitle = await waitUntilShowUp(screens.deleteImportedAccount.title)
+      assert.equal(await deleteImportedAccountTitle.getText(), screens.deleteImportedAccount.titleText)
+    })
+
+    it("Can't remove imported account with 'No' button", async function () {
+      const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.no)
+      assert.equal(await button.getText(), 'No', 'button has incorrect name')
+      await click(button)
+      const settingsTitle = await waitUntilShowUp(screens.settings.title)
+      assert.equal(await settingsTitle.getText(), 'Settings')
+      // check, that imported account still exists
+      const menu = await waitUntilShowUp(menus.account.menu)
+      await menu.click()
+      const label = await waitUntilShowUp(menus.account.label)
+      assert.equal(await label.getText(), 'IMPORTED')
+    })
+
+    it('Open delete imported account screen again', async function () {
+      const menu = await waitUntilShowUp(menus.account.delete)
+      await menu.click()
+    })
+
+    it("Remove imported account with 'Yes' button", async function () {
+      const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.yes)
+      assert.equal(await button.getText(), 'Yes', 'button has incorrect name')
+      await click(button)
+      const settingsTitle = await waitUntilShowUp(screens.settings.title)
+      assert.equal(await settingsTitle.getText(), 'Settings')
+      // check, that imported account is removed
+      const menu = await waitUntilShowUp(menus.account.menu)
+      await menu.click()
+      await waitUntilShowUp(menus.account.label, 25)
+      const labels = await driver.findElements(menus.account.label)
+      assert.ok(labels.length === 0)
+      await menu.click()
+    })
+  })
   describe('Sign Data', () => {
 
-    it('simulate sign request ', async function () {
+    it('Simulate sign request ', async function () {
       await setProvider(NETWORKS.LOCALHOST)
       await driver.get('https://danfinlay.github.io/js-eth-personal-sign-examples/')
       const button = await waitUntilShowUp(By.id('ethSignButton'))
@@ -1006,7 +1014,7 @@ describe('Metamask popup page', async function () {
     it('account name is displayed and correct', async function () {
       const name = await waitUntilShowUp(screens.signMessage.accountName)
       assert.notEqual(name, false, 'account name isn\'t displayed')
-      assert.equal(await name.getText(), 'Account 2', 'account name is incorrect')
+      assert.equal(await name.getText(), 'new name', 'account name is incorrect')
     })
 
     it('title is displayed and correct', async function () {
@@ -2890,40 +2898,40 @@ describe('Metamask popup page', async function () {
     return contractInstance.address
   }
 
-  async function executeTransferMethod(executor){
+  async function executeTransferMethod (executor) {
     try {
       const buttonExecute = await waitUntilShowUp(screens.executeMethod.buttonExecuteMethod)
       assert.notEqual(buttonExecute, false, "button doesn't displayed")
       await buttonExecute.click()
-      //Select method transfer
+      // Select method transfer
       const menu = await waitUntilShowUp(screens.executeMethod.selectArrow)
       await menu.click()
       await waitUntilShowUp(screens.executeMethod.items)
       const list = await driver.findElements(screens.executeMethod.items)
       await list[21].click()
-      //Fill out value
+      // Fill out value
       await waitUntilShowUp(screens.executeMethod.fieldParameter)
       const fields = await driver.findElements(screens.executeMethod.fieldParameter)
       assert.notEqual(fields[1], false, "field value isn't displayed")
       await fields[1].sendKeys('1')
-      //Fill out address
+      // Fill out address
       await clearField(fields[0], 100)
       await fields[0].sendKeys(account1)
       assert.notEqual(fields[0], false, "field address isn't displayed")
-      //Click button next
+      // Click button next
       const buttonNext = await waitUntilShowUp(screens.executeMethod.buttonNext)
       assert.notEqual(buttonNext, false, "button 'Next' isn't displayed")
       await buttonNext.click()
-      //Select executor
+      // Select executor
       await waitUntilShowUp(screens.chooseContractExecutor.account)
       const accounts = await driver.findElements(screens.chooseContractExecutor.account)
-      const account = accounts[executor+1]
+      const account = accounts[executor + 1]
       await account.click()
-      //Open confirm transaction
+      // Open confirm transaction
       const button = await waitUntilShowUp(screens.chooseContractExecutor.buttonNext)
       await button.click()
       return true
-    } catch (err){
+    } catch (err) {
       return false
     }
   }

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -11,6 +11,7 @@ const { menus, screens, elements, NETWORKS } = require('./elements')
 const testSeedPhrase = 'horn among position unable audit puzzle cannon apology gun autumn plug parrot'
 const account1 = '0x2E428ABd9313D256d64D1f69fe3929C3BE18fD1f'
 const account2 = '0xd7b7AFeCa35e32594e29504771aC847E2a803742'
+const createdAccounts =[]
 const eventsEmitter = 'https://vbaranov.github.io/event-listener-dapp/'
 
 describe('Metamask popup page', async function () {
@@ -74,8 +75,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe('Account Creation', async () => {
-    const newAccountName = 'new name'
+  describe('Log In', async () => {
 
     it('title is \'Nifty Wallet\'', async () => {
       const title = await driver.getTitle()
@@ -128,6 +128,9 @@ describe('Metamask popup page', async function () {
       assert.equal(await continueAfterSeedPhrase.getText(), screens.seedPhrase.textButtonIveCopied)
       await click(continueAfterSeedPhrase)
     })
+  })
+  describe('Account Creation', async () => {
+    const newAccountName = 'new name'
 
     it('sets provider type to localhost', async function () {
       await setProvider(NETWORKS.LOCALHOST)
@@ -140,7 +143,14 @@ describe('Metamask popup page', async function () {
       assert.notEqual(field, false, 'copy icon doesn\'t present')
     })
 
-    it('open  \'Account name\' change dialog', async () => {
+    it("Account's address is displayed and has length 20 symbols", async () => {
+      const field = await waitUntilShowUp(screens.main.address)
+      createdAccounts.push((await field.getText()).toUpperCase())
+      console.log(createdAccounts[0])
+      assert.notEqual(createdAccounts[0].length, 20, "address isn't displayed")
+    })
+
+    it("open 'Account name' change dialog", async () => {
       const menu = await waitUntilShowUp(menus.dot.menu)
       await menu.click()
       const field = await waitUntilShowUp(screens.main.edit)
@@ -180,10 +190,11 @@ describe('Metamask popup page', async function () {
       await item.click()
     })
 
-    it('shows account address', async function () {
-      await delay(300)
-      const account = await waitUntilShowUp(screens.main.address)
-      accountAddress = await account.getText()
+    it("Account's address is displayed and has length 20 symbols", async () => {
+      const field = await waitUntilShowUp(screens.main.address)
+      createdAccounts.push((await field.getText()).toUpperCase())
+      console.log(createdAccounts[1])
+      assert.notEqual(createdAccounts[1].length, 20, "address isn't displayed")
     })
 
     it('logs out of the vault', async () => {
@@ -213,7 +224,7 @@ describe('Metamask popup page', async function () {
     it('checks QR code address is the same as account details address', async () => {
       const field = await waitUntilShowUp(screens.QRcode.address)
       const text = await field.getText()
-      assert.equal(text.toLowerCase(), accountAddress.toLowerCase(), 'QR addres doesn\'t match')
+      assert.equal(text.toUpperCase(), createdAccounts[1], 'QR address doesn\'t match')
     })
 
     it('copy icon is displayed and clickable', async () => {
@@ -243,13 +254,100 @@ describe('Metamask popup page', async function () {
       await button.click()
     })
   })
+  describe('Import Account', () => {
 
+    it('opens import account menu', async function () {
+      await setProvider(NETWORKS.POA)
+      await delay(2000)
+      const menu = await waitUntilShowUp(menus.account.menu)
+      await menu.click()
+      const item = await waitUntilShowUp(menus.account.import)
+      await item.click()
+      const importAccountTitle = await waitUntilShowUp(screens.importAccounts.title)
+      assert.equal(await importAccountTitle.getText(), screens.importAccounts.textTitle)
+    })
+
+    it('imports account', async function () {
+      const privateKeyBox = await waitUntilShowUp(screens.importAccounts.fieldPrivateKey)
+      await privateKeyBox.sendKeys('76bd0ced0a47055bb5d060e1ae4a8cb3ece658d668823e250dae6e79d3ab4435')// 0xf4702CbA917260b2D6731Aea6385215073e8551b
+      const button = await waitUntilShowUp(screens.importAccounts.buttonImport)
+      await click(button)
+      assert.equal(await button.getText(), 'Import', 'button has incorrect name')
+      const menu = await waitUntilShowUp(menus.account.menu)
+      await menu.click()
+      await waitUntilShowUp(menus.account.labelImported)
+      const label = (await driver.findElements(menus.account.labelImported))[0]
+      assert.equal(await label.getText(), 'IMPORTED')
+      await menu.click()
+    })
+
+    it('Auto-detect tokens for POA core network ', async function () {
+      // await setProvider(NETWORKS.POA)
+      const tab = await waitUntilShowUp(screens.main.tokens.menu)
+      await tab.click()
+      const balance = await waitUntilShowUp(screens.main.tokens.balance)
+      console.log(await balance.getText())
+      assert.equal(await balance.getText(), '1 DOPR', 'token isnt\' auto-detected')
+    })
+
+    it.skip('Auto-detect tokens for MAIN core network ', async function () {
+      await setProvider(NETWORKS.MAINNET)
+      await waitUntilShowUp(elements.loader, 25)
+      await waitUntilDisappear(elements.loader, 25)
+      const balance = await waitUntilShowUp(screens.main.tokens.balance)
+      console.log(await balance.getText())
+      assert.equal(await balance.getText(), '0.001 WETH', 'token isnt\' auto-detected')
+    })
+    it('opens delete imported account screen', async function () {
+      const menu = await waitUntilShowUp(menus.account.menu)
+      await menu.click()
+      const item = await waitUntilShowUp(menus.account.delete)
+      await item.click()
+      const deleteImportedAccountTitle = await waitUntilShowUp(screens.deleteImportedAccount.title)
+      assert.equal(await deleteImportedAccountTitle.getText(), screens.deleteImportedAccount.titleText)
+    })
+
+    it('doesn\'t remove imported account with \'No\' button', async function () {
+      const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.no)
+      assert.equal(await button.getText(), 'No', 'button has incorrect name')
+      await click(button)
+      const settingsTitle = await waitUntilShowUp(screens.settings.title)
+      assert.equal(await settingsTitle.getText(), 'Settings')
+      // check, that imported account still exists
+      const menu = await waitUntilShowUp(menus.account.menu)
+      await menu.click()
+      const importedLabel = await waitUntilShowUp(menus.account.labelImported)
+      assert.equal(await importedLabel.getText(), 'IMPORTED')
+    })
+
+    it('opens delete imported account screen again', async function () {
+      const menu = await waitUntilShowUp(menus.account.delete)
+      await menu.click()
+    })
+
+    it('removes imported account with \'Yes\' button', async function () {
+      const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.yes)
+      assert.equal(await button.getText(), 'Yes', 'button has incorrect name')
+      await click(button)
+      const settingsTitle = await waitUntilShowUp(screens.settings.title)
+      assert.equal(await settingsTitle.getText(), 'Settings')
+      // check, that imported account is removed
+      const menu = await waitUntilShowUp(menus.account.menu)
+      await menu.click()
+      await waitUntilShowUp(menus.account.labelImported, 25)
+      const importedAccounts = await driver.findElements(menus.account.labelImported)
+      assert.ok(importedAccounts.length === 0)
+      await menu.click()
+    })
+
+  })
   describe('Import Contract account', async () => {
     // const poaContract = '0xc6468767214c577013a904900ada0a0dd6653bc3'
     const contractSokol = '0x215b2ab35749e5a9f3efe890de602fb9844e842f'
     console.log('Contract ' + contractSokol + ' , Sokol')
     const wrongAddress = '0xB87b6077D59B01Ab9fa8cd5A1A21D02a4d60D35'
     const notContractAddress = '0x56B2e3C3cFf7f3921Dc2e0F8B8e20d1eEc29216b'
+
     describe('Import Contract', async () => {
       it('opens import account menu', async function () {
         await setProvider(NETWORKS.ROPSTEN)
@@ -274,7 +372,6 @@ describe('Metamask popup page', async function () {
       })
 
       it("Field 'Address' is displayed", async function () {
-        await delay(2000)
         const field = await waitUntilShowUp(screens.importAccounts.contractAddress)
         assert.notEqual(field, false, "field 'Address' isn't displayed")
         await field.sendKeys(wrongAddress)
@@ -737,6 +834,7 @@ describe('Metamask popup page', async function () {
     })
     describe('Choose Contract Executor', () => {
 
+      const executor2=  '0xf4702CbA917260b2D6731Aea6385215073e8551b'
       it('title is displayed and correct', async function () {
         await delay(5000)
         const title = await waitUntilShowUp(screens.chooseContractExecutor.title)
@@ -751,7 +849,7 @@ describe('Metamask popup page', async function () {
         assert.equal(accounts.length, 3, "number of accounts isn't 2")
       })
 
-      it("Click arrow  button leads to 'Execute Method' screen ", async function () {
+      it("Click arrow button leads to 'Execute Method' screen ", async function () {
         const button = await waitUntilShowUp(screens.chooseContractExecutor.buttonArrow)
         assert.notEqual(button, false, 'button isn\'t displayed')
         await button.click()
@@ -790,16 +888,38 @@ describe('Metamask popup page', async function () {
         assert.equal(selected.length, 1, 'more than one accounts are selected')
       })
 
+
       it("Click button 'Next' open 'Confirm transaction' screen", async function () {
         const button = await waitUntilShowUp(screens.chooseContractExecutor.buttonNext)
         await button.click()
-        await delay(5000)
+        await delay(3000)
         const reject = await waitUntilShowUp(screens.confirmTransaction.button.reject)
         assert.notEqual(reject, false, "button reject isn't displayed")
-        await click(reject)
-        const identicon = await waitUntilShowUp(screens.main.identicon)
-        assert.notEqual(identicon, false, 'main screen didn\'t opened')
+
       })
+
+      it("Click button 'Reject' open contract's account screen", async function () {
+        const reject = await waitUntilShowUp(screens.confirmTransaction.button.reject)
+        await reject.click()
+        //await delay(2000)
+        const buttonExecute = await waitUntilShowUp(screens.executeMethod.buttonExecuteMethod)
+        assert.notEqual(buttonExecute, false, "contract's account hasn't opened")
+      })
+
+      it("Button arrow leads to executor's account screen", async function () {
+        assert.equal(await executeTransferMethod(0), true, "can't execute the method 'transfer'")
+        await delay(2000)
+        const arrow = await waitUntilShowUp(elements.buttonArrow)
+        await arrow.click()
+        await delay(2000)
+        const address = await waitUntilShowUp(screens.main.address)
+        assert.equal((await address.getText()).toUpperCase(),createdAccounts[0], "executors account isn't opened")
+      })
+
+      it("Stop", async function () {
+        throw("Stop!")
+      })
+
       it("Label 'CONTRACT' present", async function () {
         const menu = await waitUntilShowUp(menus.account.menu)
         await menu.click()
@@ -878,94 +998,7 @@ describe('Metamask popup page', async function () {
       assert.notEqual(identicon, false, 'main screen didn\'t opened')
     })
   })
-  describe('Import Account', () => {
 
-    it('opens import account menu', async function () {
-      await setProvider(NETWORKS.POA)
-      await delay(2000)
-      const menu = await waitUntilShowUp(menus.account.menu)
-      await menu.click()
-      const item = await waitUntilShowUp(menus.account.import)
-      await item.click()
-      const importAccountTitle = await waitUntilShowUp(screens.importAccounts.title)
-      assert.equal(await importAccountTitle.getText(), screens.importAccounts.textTitle)
-    })
-
-    it('imports account', async function () {
-      const privateKeyBox = await waitUntilShowUp(screens.importAccounts.fieldPrivateKey)
-      await privateKeyBox.sendKeys('76bd0ced0a47055bb5d060e1ae4a8cb3ece658d668823e250dae6e79d3ab4435')// 0xf4702CbA917260b2D6731Aea6385215073e8551b
-      const button = await waitUntilShowUp(screens.importAccounts.buttonImport)
-      await click(button)
-      assert.equal(await button.getText(), 'Import', 'button has incorrect name')
-      const menu = await waitUntilShowUp(menus.account.menu)
-      await menu.click()
-      await waitUntilShowUp(menus.account.labelImported)
-      const label = (await driver.findElements(menus.account.labelImported))[0]
-      assert.equal(await label.getText(), 'IMPORTED')
-      await menu.click()
-    })
-
-    it('Auto-detect tokens for POA core network ', async function () {
-      // await setProvider(NETWORKS.POA)
-      const tab = await waitUntilShowUp(screens.main.tokens.menu)
-      await tab.click()
-      const balance = await waitUntilShowUp(screens.main.tokens.balance)
-      console.log(await balance.getText())
-      assert.equal(await balance.getText(), '1 DOPR', 'token isnt\' auto-detected')
-    })
-
-    it.skip('Auto-detect tokens for MAIN core network ', async function () {
-      await setProvider(NETWORKS.MAINNET)
-      await waitUntilShowUp(elements.loader, 25)
-      await waitUntilDisappear(elements.loader, 25)
-      const balance = await waitUntilShowUp(screens.main.tokens.balance)
-      console.log(await balance.getText())
-      assert.equal(await balance.getText(), '0.001 WETH', 'token isnt\' auto-detected')
-    })
-
-    it('opens delete imported account screen', async function () {
-      await setProvider(NETWORKS.LOCALHOST)
-      const menu = await waitUntilShowUp(menus.account.menu)
-      await menu.click()
-      const item = await waitUntilShowUp(menus.account.delete)
-      await item.click()
-      const deleteImportedAccountTitle = await waitUntilShowUp(screens.deleteImportedAccount.title)
-      assert.equal(await deleteImportedAccountTitle.getText(), screens.deleteImportedAccount.titleText)
-    })
-
-    it('doesn\'t remove imported account with \'No\' button', async function () {
-      const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.no)
-      assert.equal(await button.getText(), 'No', 'button has incorrect name')
-      await click(button)
-      const settingsTitle = await waitUntilShowUp(screens.settings.title)
-      assert.equal(await settingsTitle.getText(), 'Settings')
-      // check, that imported account still exists
-      const menu = await waitUntilShowUp(menus.account.menu)
-      await menu.click()
-      const importedLabel = await waitUntilShowUp(menus.account.labelImported)
-      assert.equal(await importedLabel.getText(), 'IMPORTED')
-    })
-
-    it('opens delete imported account screen again', async function () {
-      const menu = await waitUntilShowUp(menus.account.delete)
-      await menu.click()
-    })
-
-    it('removes imported account with \'Yes\' button', async function () {
-      const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.yes)
-      assert.equal(await button.getText(), 'Yes', 'button has incorrect name')
-      await click(button)
-      const settingsTitle = await waitUntilShowUp(screens.settings.title)
-      assert.equal(await settingsTitle.getText(), 'Settings')
-      // check, that imported account is removed
-      const menu = await waitUntilShowUp(menus.account.menu)
-      await menu.click()
-      await waitUntilShowUp(menus.account.labelImported, 25)
-      const importedAccounts = await driver.findElements(menus.account.labelImported)
-      assert.ok(importedAccounts.length === 0)
-      await menu.click()
-    })
-  })
   describe('Export private key', async () => {
 
     it('open dialog', async function () {
@@ -2817,6 +2850,44 @@ describe('Metamask popup page', async function () {
     })
     if (isDelayed) await delay(5000)
     return contractInstance.address
+  }
+
+  async function executeTransferMethod(executor){
+    try {
+      const buttonExecute = await waitUntilShowUp(screens.executeMethod.buttonExecuteMethod)
+      assert.notEqual(buttonExecute, false, "button doesn't displayed")
+      await buttonExecute.click()
+      //Select method transfer
+      const menu = await waitUntilShowUp(screens.executeMethod.selectArrow)
+      await menu.click()
+      await waitUntilShowUp(screens.executeMethod.items)
+      const list = await driver.findElements(screens.executeMethod.items)
+      await list[21].click()
+      //Fill out value
+      await waitUntilShowUp(screens.executeMethod.fieldParameter)
+      const fields = await driver.findElements(screens.executeMethod.fieldParameter)
+      assert.notEqual(fields[1], false, "field value isn't displayed")
+      await fields[1].sendKeys('1')
+      //Fill out address
+      await clearField(fields[0], 100)
+      await fields[0].sendKeys(account1)
+      assert.notEqual(fields[0], false, "field address isn't displayed")
+      //Click button next
+      const buttonNext = await waitUntilShowUp(screens.executeMethod.buttonNext)
+      assert.notEqual(buttonNext, false, "button 'Next' isn't displayed")
+      await buttonNext.click()
+      //Select executor
+      await waitUntilShowUp(screens.chooseContractExecutor.account)
+      const accounts = await driver.findElements(screens.chooseContractExecutor.account)
+      const account = accounts[executor+1]
+      await account.click()
+      //Open confirm transaction
+      const button = await waitUntilShowUp(screens.chooseContractExecutor.buttonNext)
+      await button.click()
+      return true
+    } catch (err){
+      return false
+    }
   }
 
 })

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -533,6 +533,7 @@ describe('Metamask popup page', async function () {
         it("Select method 'returnString'", async function () {
           const field = await waitUntilShowUp(screens.executeMethod.selectArrow)
           await field.click()
+          await delay(2000)
           await waitUntilShowUp(screens.executeMethod.items)
           const list = await driver.findElements(screens.executeMethod.items)
           await list[14].click()
@@ -916,8 +917,45 @@ describe('Metamask popup page', async function () {
         assert.equal((await address.getText()).toUpperCase(),createdAccounts[0], "executors account isn't opened")
       })
 
+     it('Switch to contract account ', async function () {
+        const accountMenu = await waitUntilShowUp(menus.account.menu)
+        await accountMenu.click()
+        const item = await waitUntilShowUp(menus.account.account3)
+        await item.click()
+        await delay(2000)
+        const address = await waitUntilShowUp(screens.main.address)
+        assert.equal((await address.getText()).toUpperCase(),contractSokol.toUpperCase(), "contract's account isn't opened")
+      })
+
+      it("Confirm transaction: button 'Reject All' leads to executor's account screen", async function () {
+        assert.equal(await executeTransferMethod(0), true, "can't execute the method 'transfer'")
+        const rejectAll = await waitUntilShowUp(screens.confirmTransaction.button.rejectAll)
+        await rejectAll.click()
+        await delay(2000)
+        const address = await waitUntilShowUp(screens.main.address)
+        assert.equal((await address.getText()).toUpperCase(),contractSokol.toUpperCase(), "executors account isn't opened")
+      })
+
+      it("Confirm transaction: button 'Submit' leads to executor's account screen", async function () {
+        assert.equal(await executeTransferMethod(1), true, "can't execute the method 'transfer'")
+        await delay(2000)
+        const  button = await waitUntilShowUp(screens.confirmTransaction.button.submit)
+        await button.click()
+        await delay(2000)
+        const address = await waitUntilShowUp(screens.main.address)
+        assert.equal((await address.getText()).toUpperCase(),contractSokol.toUpperCase(), "executors account isn't opened")
+      })
+
+
       it("Stop", async function () {
         throw("Stop!")
+        const balanceField = await waitUntilShowUp(screens.main.balance)
+        await delay(2000)
+        const balance = await balanceField.getText()
+        console.log('Account = ' + account)
+        console.log('Balance = ' + balance)
+        assert.equal(parseFloat(balance) > 0.001, true, 'Balance of account ' + account + ' TOO LOW !!! Please refill with Sokol eth!!!!')
+
       })
 
       it("Label 'CONTRACT' present", async function () {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -977,7 +977,7 @@ describe('Metamask popup page', async function () {
 
     it('Open delete imported account screen again', async function () {
       await waitUntilShowUp(menus.account.delete)
-      const buttons = await driver.findElement(menus.account.delete)
+      const buttons = await driver.findElements(menus.account.delete)
       assert.notEqual(buttons[0], false, "icon 'remove' isn't displayed")
       await buttons[0].click()
     })

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -976,12 +976,13 @@ describe('Metamask popup page', async function () {
     })
 
     it('Open delete imported account screen again', async function () {
-      const menu = await waitUntilShowUp(menus.account.delete)
-      await menu.click()
+      await waitUntilShowUp(menus.account.delete)
+      const buttons = await driver.findElement(menus.account.delete)
+      assert.notEqual(buttons[0], false, "icon 'remove' isn't displayed")
+      await buttons[0].click()
     })
 
     it("Remove imported account with 'Yes' button", async function () {
-
       const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.yes)
       assert.equal(await button.getText(), 'Yes', 'button has incorrect name')
       await click(button)
@@ -996,8 +997,8 @@ describe('Metamask popup page', async function () {
       await menu.click()
     })
   })
-  describe('Sign Data', () => {
 
+  describe('Sign Data', () => {
     it('Simulate sign request ', async function () {
       await setProvider(NETWORKS.LOCALHOST)
       await driver.get('https://danfinlay.github.io/js-eth-personal-sign-examples/')

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -903,23 +903,23 @@ describe('Metamask popup page', async function () {
         assert.equal((await address.getText()).toUpperCase(), contractSokol.toUpperCase(), "contract's account isn't opened")
       })
 
-      it("Confirm transaction: button 'Reject All' leads to executor's account screen", async function () {
+      it("Confirm transaction: button 'Reject All' leads to contract's account screen", async function () {
         assert.equal(await executeTransferMethod(0), true, "can't execute the method 'transfer'")
         const rejectAll = await waitUntilShowUp(screens.confirmTransaction.button.rejectAll)
         await rejectAll.click()
         await delay(2000)
         const address = await waitUntilShowUp(screens.main.address)
-        assert.equal((await address.getText()).toUpperCase(), contractSokol.toUpperCase(), "executors account isn't opened")
+        assert.equal((await address.getText()).toUpperCase(), contractSokol.toUpperCase(), "contract account isn't opened")
       })
 
-      it("Confirm transaction: button 'Submit' leads to executor's account screen", async function () {
+      it("Confirm transaction: button 'Submit' leads to contract's account screen", async function () {
         assert.equal(await executeTransferMethod(2), true, "can't execute the method 'transfer'")
         await delay(2000)
         const button = await waitUntilShowUp(screens.confirmTransaction.button.submit)
         await button.click()
         await delay(2000)
         const address = await waitUntilShowUp(screens.main.address)
-        assert.equal((await address.getText()).toUpperCase(), contractSokol.toUpperCase(), "executors account isn't opened")
+        assert.equal((await address.getText()).toUpperCase(), contractSokol.toUpperCase(), "contract account isn't opened")
       })
 
      it("Label 'CONTRACT' present", async function () {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -976,6 +976,10 @@ describe('Metamask popup page', async function () {
     })
 
     it('Open delete imported account screen again', async function () {
+      const menu = await waitUntilShowUp(menus.account.menu)
+      await menu.click()
+      await delay(2000)
+      await menu.click()
       await waitUntilShowUp(menus.account.delete)
       const buttons = await driver.findElements(menus.account.delete)
       assert.notEqual(buttons[0], false, "icon 'remove' isn't displayed")

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -866,7 +866,13 @@ describe('Metamask popup page', async function () {
         assert.notEqual(reject, false, "button reject isn't displayed")
       })
 
-      it("Button 'Buy Ether' is displayed and enabled", async function () {
+      it("Button 'Buy Ether' is displayed", async function () {
+        const button = await waitUntilShowUp(screens.confirmTransaction.button.buyEther)
+        assert.equal(await button.getText(), 'Buy Ether', 'button has incorrect name')
+        assert.equal(await button.isEnabled(), true, 'button is disabled')
+      })
+
+      it("Open screen 'Buy Ether'", async function () {
         const button = await waitUntilShowUp(screens.confirmTransaction.button.buyEther)
         await button.click()
         const title = await waitUntilShowUp(screens.buyEther.title)
@@ -877,8 +883,8 @@ describe('Metamask popup page', async function () {
 
       it("Click button 'Reject' open contract's account screen", async function () {
         const reject = await waitUntilShowUp(screens.confirmTransaction.button.reject)
+        assert.equal(await reject.getText(), 'Reject', 'button has incorrect name')
         await reject.click()
-        // await delay(2000)
         const buttonExecute = await waitUntilShowUp(screens.executeMethod.buttonExecuteMethod)
         assert.notEqual(buttonExecute, false, "contract's account hasn't opened")
       })
@@ -906,6 +912,7 @@ describe('Metamask popup page', async function () {
       it("Confirm transaction: button 'Reject All' leads to contract's account screen", async function () {
         assert.equal(await executeTransferMethod(0), true, "can't execute the method 'transfer'")
         const rejectAll = await waitUntilShowUp(screens.confirmTransaction.button.rejectAll)
+        assert.equal(await rejectAll.getText(), 'Reject All', 'button has incorrect name')
         await rejectAll.click()
         await delay(2000)
         const address = await waitUntilShowUp(screens.main.address)
@@ -916,6 +923,7 @@ describe('Metamask popup page', async function () {
         assert.equal(await executeTransferMethod(2), true, "can't execute the method 'transfer'")
         await delay(2000)
         const button = await waitUntilShowUp(screens.confirmTransaction.button.submit)
+        // assert.equal(await button.getText(), 'Submit', "button has incorrect name")
         await button.click()
         await delay(2000)
         const address = await waitUntilShowUp(screens.main.address)
@@ -962,6 +970,7 @@ describe('Metamask popup page', async function () {
       // check, that imported account still exists
       const menu = await waitUntilShowUp(menus.account.menu)
       await menu.click()
+      await delay(2000)
       const label = await waitUntilShowUp(menus.account.label)
       assert.equal(await label.getText(), 'IMPORTED')
     })
@@ -972,6 +981,7 @@ describe('Metamask popup page', async function () {
     })
 
     it("Remove imported account with 'Yes' button", async function () {
+
       const button = await waitUntilShowUp(screens.deleteImportedAccount.buttons.yes)
       assert.equal(await button.getText(), 'Yes', 'button has incorrect name')
       await click(button)


### PR DESCRIPTION
Relates https://github.com/poanetwork/nifty-wallet/pull/238
Added tests for ‘Confirm transaction’ screen, checks behaviour of buttons:     
       ✓ Button 'Buy Ether' is displayed (131ms)
        ✓ Open screen 'Buy Ether' (859ms)
        ✓ Click button 'Reject' open contract's account screen (465ms)
        ✓ Button arrow leads to executor's account screen (7762ms)
        ✓ Switch to contract account  (2835ms)
        ✓ Confirm transaction: button 'Reject All' leads to contract's account screen (5788ms)
        ✓ Confirm transaction: button 'Submit' leads to contract's account screen (7727ms)

 
