### PR TITLE
(Refactoring) Send-token component

### DIFF
--- a/old-ui/app/account-detail.js
+++ b/old-ui/app/account-detail.js
@@ -27,7 +27,6 @@ function mapStateToProps (state) {
     identities: state.metamask.identities,
     keyrings: state.metamask.keyrings,
     warning: state.appState.warning,
-    toastMsg: state.appState.toastMsg,
     accounts,
     address: state.metamask.selectedAddress,
     accountDetail: state.appState.accountDetail,
@@ -68,7 +67,6 @@ AccountDetailScreen.prototype.render = function () {
     h('.account-detail-section.full-flex-height', [
 
       h(ToastComponent, {
-        msg: props.toastMsg,
         isSuccess: false,
       }),
 

--- a/old-ui/app/components/account-dropdowns.js
+++ b/old-ui/app/components/account-dropdowns.js
@@ -132,7 +132,6 @@ class AccountDropdowns extends Component {
     this.props.actions.showAccountDetail(address)
     if (ifHardwareAcc(keyring)) {
       if (isLedger(keyring.type)) {
-
         const hdPaths = getHdPaths()
         return new Promise((resolve, reject) => {
           this.props.actions.connectHardwareAndUnlockAddress(LEDGER, hdPaths[1].value, address)
@@ -147,15 +146,23 @@ class AccountDropdowns extends Component {
           if (!this.state.preventToast) {
             this.props.actions.displayToast(e)
           } else {
-            this.setState({preventToast: false})
+            this.allowToast()
           }
         })
       } else {
-        this.setState({preventToast: true})
+        this.preventToast()
       }
     } else {
-        this.setState({preventToast: true})
+        this.preventToast()
     }
+  }
+
+  allowToast () {
+    this.setState({preventToast: false})
+  }
+
+  preventToast () {
+    this.setState({preventToast: true})
   }
 
   ifProxyAcc (address, setProxy) {

--- a/old-ui/app/components/account-dropdowns.js
+++ b/old-ui/app/components/account-dropdowns.js
@@ -42,6 +42,7 @@ class AccountDropdowns extends Component {
       labels: {},
       isProxy: false,
       contractProps: null,
+      preventToast: false,
     }
     this.accountSelectorToggleClassName = 'accounts-selector'
     this.optionsMenuToggleClassName = 'account-dropdown'
@@ -131,6 +132,7 @@ class AccountDropdowns extends Component {
     this.props.actions.showAccountDetail(address)
     if (ifHardwareAcc(keyring)) {
       if (isLedger(keyring.type)) {
+
         const hdPaths = getHdPaths()
         return new Promise((resolve, reject) => {
           this.props.actions.connectHardwareAndUnlockAddress(LEDGER, hdPaths[1].value, address)
@@ -142,10 +144,17 @@ class AccountDropdowns extends Component {
           })
         })
         .catch(e => {
-          this.props.actions.displayWarning((e && e.message) || e)
-          this.props.actions.displayToast(e)
+          if (!this.state.preventToast) {
+            this.props.actions.displayToast(e)
+          } else {
+            this.setState({preventToast: false})
+          }
         })
+      } else {
+        this.setState({preventToast: true})
       }
+    } else {
+        this.setState({preventToast: true})
     }
   }
 

--- a/old-ui/app/components/account-dropdowns.js
+++ b/old-ui/app/components/account-dropdowns.js
@@ -405,8 +405,8 @@ class AccountDropdowns extends Component {
     const { selected, keyrings } = this.props
     if (prevProps.selected !== selected) {
       this.checkIfProxy()
-    }
-    if (prevProps.keyrings.length !== keyrings.length) {
+      this.setAllLabels()
+    } else if (prevProps.keyrings.length !== keyrings.length) {
       this.setAllLabels()
     }
     if (!isNaN(this.props.network)) {

--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -26,6 +26,7 @@ const { tokenInfoGetter, calcTokenAmount } = require('../../../ui/app/token-util
 const BigNumber = require('bignumber.js')
 const ethNetProps = require('eth-net-props')
 import { getMetaMaskAccounts } from '../../../ui/app/selectors'
+import ToastComponent from './toast'
 
 const MIN_GAS_PRICE_BN = new BN('0')
 const MIN_GAS_LIMIT_BN = new BN('21000')
@@ -168,6 +169,9 @@ PendingTx.prototype.render = function () {
     h('div', {
       key: txMeta.id,
     }, [
+      h(ToastComponent, {
+        isSuccess: false,
+      }),
 
       h('form#pending-tx-form', {
         onSubmit: this.onSubmit.bind(this),

--- a/old-ui/app/components/send/send-contract.js
+++ b/old-ui/app/components/send/send-contract.js
@@ -152,7 +152,7 @@ class SendTransactionScreen extends PersistentForm {
 				<SendProfile />
 				<SendHeader title="Execute Method" />
 				<ErrorComponent error={error} />
-				<ToastComponent msg={this.props.toastMsg} isSuccess={true} />
+				<ToastComponent isSuccess={true} />
 				<div style={{ padding: '0 30px' }}>
 					<Select
 						clearable={false}
@@ -470,7 +470,6 @@ function mapStateToProps (state) {
 	const result = {
 		address: state.metamask.selectedAddress,
 		warning: state.appState.warning,
-		toastMsg: state.appState.toastMsg,
 		methodSelected: contractAcc && contractAcc.methodSelected,
 		methodABI: contractAcc && contractAcc.methodABI,
 		inputValues: contractAcc && contractAcc.inputValues,

--- a/old-ui/app/components/send/send-token.js
+++ b/old-ui/app/components/send/send-token.js
@@ -1,31 +1,276 @@
-const inherits = require('util').inherits
-const PersistentForm = require('../../../lib/persistent-form')
-const h = require('react-hyperscript')
-const connect = require('react-redux').connect
-const actions = require('../../../../ui/app/actions')
-const {
+import React from 'react'
+import PersistentForm from '../../../lib/persistent-form'
+import { connect } from 'react-redux'
+import actions from '../../../../ui/app/actions'
+import {
   numericBalance,
   isInvalidChecksumAddress,
   isValidAddress,
-} = require('../../util')
-const EnsInput = require('../ens-input')
-const ethUtil = require('ethereumjs-util')
-const { tokenInfoGetter, calcTokenAmountWithDec } = require('../../../../ui/app/token-util')
-const TokenTracker = require('eth-token-watcher')
-const Loading = require('../loading')
-const BigNumber = require('bignumber.js')
+} from '../../util'
+import EnsInput from '../ens-input'
+import ethUtil from 'ethereumjs-util'
+import { tokenInfoGetter, calcTokenAmountWithDec } from '../../../../ui/app/token-util'
+import TokenTracker from 'eth-token-watcher'
+import Loading from '../loading'
+import BigNumber from 'bignumber.js'
 BigNumber.config({ ERRORS: false })
-const log = require('loglevel')
+import log from 'loglevel'
 import SendProfile from './send-profile'
 import SendHeader from './send-header'
 import ErrorComponent from '../error'
 import { getMetaMaskAccounts } from '../../../../ui/app/selectors'
 
-module.exports = connect(mapStateToProps)(SendTransactionScreen)
+class SendTransactionScreen extends PersistentForm {
+  constructor (props) {
+    super(props)
+    this.state = {
+      token: {
+        address: '',
+        symbol: '',
+        balance: 0,
+        decimals: 0,
+      },
+      amount: '',
+      isLoading: true,
+    }
+    PersistentForm.call(this)
+  }
+  render () {
+    const { isLoading, token, amount } = this.state
+    if (isLoading) {
+      return (
+        <Loading isLoading={isLoading} loadingMessage="Loading..." />
+      )
+    }
+    this.persistentFormParentId = 'send-tx-form'
 
-function mapStateToProps (state) {
+    const props = this.props
+    const {
+      network,
+      identities,
+      addressBook,
+      error,
+    } = props
+    const nextDisabled = token.balance <= 0
+
+    return (
+
+      <div className="send-screen flex-column flex-grow">
+        <SendProfile isToken={true} token={token} />
+        <SendHeader title={`Send ${this.state.token.symbol} Tokens`} />
+        <ErrorComponent error={error} />
+        <section className="flex-row flex-center">
+          <EnsInput
+            name="address"
+            placeholder="Recipient Address"
+            onChange={() => this.recipientDidChange.bind(this)}
+            network={network}
+            identities={identities}
+            addressBook={addressBook}
+          />
+        </section>
+        <section className="flex-row flex-center">
+          <input className="large-input"
+            name="amount"
+            value={amount}
+            onChange={(e) => this.amountDidChange(e.target.value)}
+            placeholder="Amount"
+            type="number"
+            style={{
+              marginRight: '6px',
+            }}
+          />
+          <button
+            onClick={() => this.onSubmit()}
+            disabled={nextDisabled}
+          >Next
+          </button>
+        </section>
+      </div>
+    )
+  }
+
+  componentDidMount () {
+    this.getTokensMetadata()
+    .then(() => {
+      this.createFreshTokenTracker()
+    })
+  }
+
+  async getTokensMetadata () {
+    this.setState({isLoading: true})
+    this.tokenInfoGetter = tokenInfoGetter()
+    const { tokenAddress, network } = this.props
+    const { symbol = '', decimals = 0 } = await this.tokenInfoGetter(tokenAddress)
+    this.setState({
+      token: {
+        address: tokenAddress,
+        network,
+        symbol,
+        decimals,
+      },
+    })
+
+    return Promise.resolve()
+  }
+
+  componentWillUnmount () {
+    this.props.displayWarning()
+    if (!this.tracker) return
+    this.tracker.stop()
+    this.tracker.removeListener('update', this.balanceUpdater)
+    this.tracker.removeListener('error', this.showError)
+  }
+
+  createFreshTokenTracker () {
+    this.setState({isLoading: true})
+    const { address, tokenAddress } = this.props
+    if (!isValidAddress(tokenAddress)) return
+    if (this.tracker) {
+      // Clean up old trackers when refreshing:
+      this.tracker.stop()
+      this.tracker.removeListener('update', this.balanceUpdater)
+      this.tracker.removeListener('error', this.showError)
+    }
+
+    if (!global.ethereumProvider) return
+
+    this.tracker = new TokenTracker({
+      userAddress: address,
+      provider: global.ethereumProvider,
+      tokens: [this.state.token],
+      pollingInterval: 8000,
+    })
+
+
+    // Set up listener instances for cleaning up
+    this.balanceUpdater = this.updateBalances.bind(this)
+    this.showError = (error) => {
+      this.setState({ error, isLoading: false })
+    }
+    this.tracker.on('update', this.balanceUpdater)
+    this.tracker.on('error', this.showError)
+
+    this.tracker.updateBalances()
+    .then(() => {
+      this.updateBalances(this.tracker.serialize())
+    })
+    .catch((reason) => {
+      log.error(`Problem updating balances`, reason)
+      this.setState({ isLoading: false })
+    })
+  }
+
+  updateBalances (tokens) {
+    if (!this.tracker.running) {
+      return
+    }
+    this.setState({ token: (tokens && tokens[0]), isLoading: false })
+  }
+
+  recipientDidChange (recipient, nickname) {
+    console.log('recipient, nickname')
+    console.log(recipient, nickname)
+    this.setState({
+      recipient,
+      nickname,
+    })
+  }
+
+  amountDidChange (amount) {
+    this.setState({
+      amount,
+    })
+  }
+
+  async onSubmit () {
+    const state = this.state || {}
+    const { token, amount } = state
+    const recipient = state.recipient || document.querySelector('input[name="address"]').value.replace(/^[.\s]+|[.\s]+$/g, '')
+    const nickname = state.nickname || ' '
+    const parts = amount.split('.')
+
+    let message
+
+    if (isNaN(amount) || amount === '') {
+      message = 'Invalid token\'s amount.'
+      return this.props.displayWarning(message)
+    }
+
+    if (parts[1]) {
+      const decimal = parts[1]
+      if (decimal.length > 18) {
+        message = 'Token\'s amount is too precise.'
+        return this.props.displayWarning(message)
+      }
+    }
+
+    const tokenAddress = ethUtil.addHexPrefix(token.address)
+    const tokensValueWithoutDec = new BigNumber(amount)
+    const tokensValueWithDec = new BigNumber(calcTokenAmountWithDec(amount, token.decimals))
+
+    if (tokensValueWithDec.gt(token.balance)) {
+      message = 'Insufficient token\'s balance.'
+      return this.props.displayWarning(message)
+    }
+
+    if (amount < 0) {
+      message = 'Can not send negative amounts of ETH.'
+      return this.props.displayWarning(message)
+    }
+
+    if ((isInvalidChecksumAddress(recipient))) {
+      message = 'Recipient address checksum is invalid.'
+      return this.props.displayWarning(message)
+    }
+
+    if (!isValidAddress(recipient) || (!recipient)) {
+      message = 'Recipient address is invalid.'
+      return this.props.displayWarning(message)
+    }
+
+    this.props.hideWarning()
+
+    this.props.addToAddressBook(recipient, nickname)
+
+    const txParams = {
+      from: this.props.address,
+      value: '0x',
+    }
+
+    const toAddress = ethUtil.addHexPrefix(recipient)
+
+    txParams.to = tokenAddress
+
+    const tokensAmount = `0x${amount.toString(16)}`
+    const encoded = this.generateTokenTransferData({toAddress, amount: tokensAmount})
+    txParams.data = encoded
+
+    const confTxScreenParams = {
+      isToken: true,
+      tokenSymbol: token.symbol,
+      tokensToSend: tokensValueWithoutDec,
+      tokensTransferTo: toAddress,
+    }
+
+    this.props.signTokenTx(tokenAddress, toAddress, tokensValueWithDec, txParams, confTxScreenParams)
+  }
+
+  generateTokenTransferData ({ toAddress = '0x0', amount = '0x0' }) {
+    const TOKEN_TRANSFER_FUNCTION_SIGNATURE = '0xa9059cbb'
+    const abi = require('ethereumjs-abi')
+    return TOKEN_TRANSFER_FUNCTION_SIGNATURE + Array.prototype.map.call(
+      abi.rawEncode(['address', 'uint256'], [toAddress, ethUtil.addHexPrefix(amount)]),
+      x => ('00' + x.toString(16)).slice(-2)
+    ).join('')
+  }
+
+}
+
+
+const mapStateToProps = (state) => {
   const accounts = getMetaMaskAccounts(state)
-  var result = {
+  const result = {
     address: state.metamask.selectedAddress,
     accounts,
     identities: state.metamask.identities,
@@ -43,269 +288,20 @@ function mapStateToProps (state) {
   return result
 }
 
-inherits(SendTransactionScreen, PersistentForm)
-function SendTransactionScreen () {
-  this.state = {
-    token: {
-      address: '',
-      symbol: '',
-      balance: 0,
-      decimals: 0,
-    },
-    isLoading: true,
+const mapDispatchToProps = dispatch => {
+  return {
+    showAccountsPage: () => dispatch(actions.showAccountsPage()),
+    displayWarning: warning => dispatch(actions.displayWarning(warning)),
+    hideWarning: () => dispatch(actions.hideWarning()),
+    addToAddressBook: (recipient, nickname) => dispatch(actions.addToAddressBook(recipient, nickname)),
+    signTokenTx: (
+      tokenAddress,
+      toAddress,
+      tokensValueWithDec,
+      txParams,
+      confTxScreenParams
+    ) => dispatch(actions.signTokenTx(tokenAddress, toAddress, tokensValueWithDec, txParams, confTxScreenParams)),
   }
-  PersistentForm.call(this)
 }
 
-SendTransactionScreen.prototype.render = function () {
-  const { isLoading, token } = this.state
-  if (isLoading) {
-    return h(Loading, {
-      isLoading: isLoading,
-      loadingMessage: 'Loading...',
-    })
-  }
-  this.persistentFormParentId = 'send-tx-form'
-
-  const props = this.props
-  const {
-    network,
-    identities,
-    addressBook,
-    error,
-  } = props
-
-  return (
-
-    h('.send-screen.flex-column.flex-grow', [
-
-      //
-      // Sender Profile
-      //
-
-      h(SendProfile, {
-        isToken: true,
-        token,
-      }),
-
-      //
-      // Send Header
-      //
-
-      h(SendHeader, {
-        title: `Send ${this.state.token.symbol} Tokens`,
-      }),
-
-      // error message
-      h(ErrorComponent, {
-        error,
-      }),
-
-      // 'to' field
-      h('section.flex-row.flex-center', [
-        h(EnsInput, {
-          name: 'address',
-          placeholder: 'Recipient Address',
-          onChange: this.recipientDidChange.bind(this),
-          network,
-          identities,
-          addressBook,
-        }),
-      ]),
-
-      // 'amount' and send button
-      h('section.flex-row.flex-center', [
-
-        h('input.large-input', {
-          name: 'amount',
-          placeholder: 'Amount',
-          type: 'number',
-          style: {
-            marginRight: '6px',
-          },
-          dataset: {
-            persistentFormId: 'tx-amount',
-          },
-        }),
-
-        h('button', {
-          onClick: this.onSubmit.bind(this),
-        }, 'Next'),
-
-      ]),
-    ])
-  )
-}
-
-SendTransactionScreen.prototype.componentDidMount = function () {
-  this.getTokensMetadata()
-  .then(() => {
-    this.createFreshTokenTracker()
-  })
-}
-
-SendTransactionScreen.prototype.getTokensMetadata = async function () {
-  this.setState({isLoading: true})
-  this.tokenInfoGetter = tokenInfoGetter()
-  const { tokenAddress, network } = this.props
-  const { symbol = '', decimals = 0 } = await this.tokenInfoGetter(tokenAddress)
-  this.setState({
-    token: {
-      address: tokenAddress,
-      network,
-      symbol,
-      decimals,
-    },
-  })
-
-  return Promise.resolve()
-}
-
-SendTransactionScreen.prototype.componentWillUnmount = function () {
-  this.props.dispatch(actions.displayWarning(''))
-  if (!this.tracker) return
-  this.tracker.stop()
-  this.tracker.removeListener('update', this.balanceUpdater)
-  this.tracker.removeListener('error', this.showError)
-}
-
-SendTransactionScreen.prototype.createFreshTokenTracker = function () {
-  this.setState({isLoading: true})
-  const { address, tokenAddress } = this.props
-  if (!isValidAddress(tokenAddress)) return
-  if (this.tracker) {
-    // Clean up old trackers when refreshing:
-    this.tracker.stop()
-    this.tracker.removeListener('update', this.balanceUpdater)
-    this.tracker.removeListener('error', this.showError)
-  }
-
-  if (!global.ethereumProvider) return
-
-  this.tracker = new TokenTracker({
-    userAddress: address,
-    provider: global.ethereumProvider,
-    tokens: [this.state.token],
-    pollingInterval: 8000,
-  })
-
-
-  // Set up listener instances for cleaning up
-  this.balanceUpdater = this.updateBalances.bind(this)
-  this.showError = (error) => {
-    this.setState({ error, isLoading: false })
-  }
-  this.tracker.on('update', this.balanceUpdater)
-  this.tracker.on('error', this.showError)
-
-  this.tracker.updateBalances()
-  .then(() => {
-    this.updateBalances(this.tracker.serialize())
-  })
-  .catch((reason) => {
-    log.error(`Problem updating balances`, reason)
-    this.setState({ isLoading: false })
-  })
-}
-
-SendTransactionScreen.prototype.updateBalances = function (tokens) {
-  if (!this.tracker.running) {
-    return
-  }
-  this.setState({ token: (tokens && tokens[0]), isLoading: false })
-}
-
-SendTransactionScreen.prototype.navigateToAccounts = function (event) {
-  event.stopPropagation()
-  this.props.dispatch(actions.showAccountsPage())
-}
-
-SendTransactionScreen.prototype.recipientDidChange = function (recipient, nickname) {
-  this.setState({
-    recipient: recipient,
-    nickname: nickname,
-  })
-}
-
-SendTransactionScreen.prototype.onSubmit = async function () {
-  const state = this.state || {}
-  const { token } = state
-  const recipient = state.recipient || document.querySelector('input[name="address"]').value.replace(/^[.\s]+|[.\s]+$/g, '')
-  const nickname = state.nickname || ' '
-  const input = document.querySelector('input[name="amount"]').value
-  const parts = input.split('.')
-
-  let message
-
-  if (isNaN(input) || input === '') {
-    message = 'Invalid token\'s amount.'
-    return this.props.dispatch(actions.displayWarning(message))
-  }
-
-  if (parts[1]) {
-    var decimal = parts[1]
-    if (decimal.length > 18) {
-      message = 'Token\'s amount is too precise.'
-      return this.props.dispatch(actions.displayWarning(message))
-    }
-  }
-
-  const tokenAddress = ethUtil.addHexPrefix(token.address)
-  const tokensValueWithoutDec = new BigNumber(input)
-  const tokensValueWithDec = new BigNumber(calcTokenAmountWithDec(input, token.decimals))
-
-  if (tokensValueWithDec.gt(token.balance)) {
-    message = 'Insufficient token\'s balance.'
-    return this.props.dispatch(actions.displayWarning(message))
-  }
-
-  if (input < 0) {
-    message = 'Can not send negative amounts of ETH.'
-    return this.props.dispatch(actions.displayWarning(message))
-  }
-
-  if ((isInvalidChecksumAddress(recipient))) {
-    message = 'Recipient address checksum is invalid.'
-    return this.props.dispatch(actions.displayWarning(message))
-  }
-
-  if (!isValidAddress(recipient) || (!recipient)) {
-    message = 'Recipient address is invalid.'
-    return this.props.dispatch(actions.displayWarning(message))
-  }
-
-  this.props.dispatch(actions.hideWarning())
-
-  this.props.dispatch(actions.addToAddressBook(recipient, nickname))
-
-  var txParams = {
-    from: this.props.address,
-    value: '0x',
-  }
-
-  const toAddress = ethUtil.addHexPrefix(recipient)
-
-  txParams.to = tokenAddress
-
-  const tokensAmount = `0x${input.toString(16)}`
-  const encoded = this.generateTokenTransferData({toAddress, amount: tokensAmount})
-  txParams.data = encoded
-
-  const confTxScreenParams = {
-    isToken: true,
-    tokenSymbol: token.symbol,
-    tokensToSend: tokensValueWithoutDec,
-    tokensTransferTo: toAddress,
-  }
-
-  this.props.dispatch(actions.signTokenTx(tokenAddress, toAddress, tokensValueWithDec, txParams, confTxScreenParams))
-}
-
-SendTransactionScreen.prototype.generateTokenTransferData = function ({ toAddress = '0x0', amount = '0x0' }) {
-  const TOKEN_TRANSFER_FUNCTION_SIGNATURE = '0xa9059cbb'
-  const abi = require('ethereumjs-abi')
-  return TOKEN_TRANSFER_FUNCTION_SIGNATURE + Array.prototype.map.call(
-    abi.rawEncode(['address', 'uint256'], [toAddress, ethUtil.addHexPrefix(amount)]),
-    x => ('00' + x.toString(16)).slice(-2)
-  ).join('')
-}
+module.exports = connect(mapStateToProps, mapDispatchToProps)(SendTransactionScreen)

--- a/old-ui/app/components/send/send-token.js
+++ b/old-ui/app/components/send/send-token.js
@@ -169,8 +169,6 @@ class SendTransactionScreen extends PersistentForm {
   }
 
   recipientDidChange (recipient, nickname) {
-    console.log('recipient, nickname')
-    console.log(recipient, nickname)
     this.setState({
       recipient,
       nickname,

--- a/old-ui/app/components/send/send.js
+++ b/old-ui/app/components/send/send.js
@@ -16,6 +16,7 @@ import SendProfile from './send-profile'
 import SendHeader from './send-header'
 import ErrorComponent from '../error'
 import { getMetaMaskAccounts } from '../../../../ui/app/selectors'
+import ToastComponent from '../toast'
 module.exports = connect(mapStateToProps)(SendTransactionScreen)
 
 function mapStateToProps (state) {
@@ -55,6 +56,10 @@ SendTransactionScreen.prototype.render = function () {
   return (
 
     h('.send-screen.flex-column.flex-grow', [
+
+      h(ToastComponent, {
+        isSuccess: false,
+      }),
 
       //
       // Sender Profile

--- a/old-ui/app/components/toast.js
+++ b/old-ui/app/components/toast.js
@@ -7,6 +7,7 @@ import actions from '../../../ui/app/actions'
 class ToastComponent extends Component {
 	static propTypes = {
 		msg: PropTypes.string,
+		toastMsg: PropTypes.string,
 		isSuccess: PropTypes.bool,
 		hideToast: PropTypes.func,
 	}
@@ -17,7 +18,7 @@ class ToastComponent extends Component {
 	}
 
 	componentDidUpdate (prevProps) {
-		if (!prevProps.msg && this.props.msg) {
+		if ((!prevProps.msg && this.props.msg) || (!prevProps.toastMsg && this.props.toastMsg)) {
 			this.timerID = setTimeout(() => {
 				this.props.hideToast()
 				clearTimeout(this.timerID)
@@ -31,15 +32,16 @@ class ToastComponent extends Component {
 	}
 
 	render () {
-		const { msg } = this.props
-		return msg ? (
+		let toastMsg = this.props.msg || this.props.toastMsg
+		toastMsg = (toastMsg && toastMsg.message) || toastMsg
+		return toastMsg ? (
 			<div
 				className={classnames('toast', {
 					'green': this.props.isSuccess,
 					'red': !this.props.isSuccess,
 				})}
 				onClick={(e) => this.props.hideToast()}
-			>{(msg && msg.message) || msg}</div>
+			>{toastMsg}</div>
 		) : null
 	}
 }

--- a/old-ui/app/util.js
+++ b/old-ui/app/util.js
@@ -26,6 +26,7 @@ module.exports = {
   miniAddressSummary: miniAddressSummary,
   isAllOneCase: isAllOneCase,
   isValidAddress: isValidAddress,
+  isValidENSAddress,
   numericBalance: numericBalance,
   parseBalance: parseBalance,
   formatBalance: formatBalance,
@@ -80,6 +81,10 @@ function isValidAddress (address) {
   var prefixed = ethUtil.addHexPrefix(address)
   if (address === '0x0000000000000000000000000000000000000000') return false
   return (isAllOneCase(prefixed) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
+}
+
+function isValidENSAddress (address) {
+  return address.match(/^.{7,}\.(eth|test)$/)
 }
 
 function isInvalidChecksumAddress (address) {


### PR DESCRIPTION
`Send-token` component refactoring to using of JSX and ES modules

Also, 

- improving hardware warnings toast appearance (add toast component to the `send` and `pending tx` screens, show toast only when we hardware acc is still selected)
- refactoring of toast component
- get upstream from parent repo for `ens-input` component