### PR TITLE
(Fix) ENS validation fix for Send transaction screen

### DIFF
--- a/old-ui/app/components/ens-input.js
+++ b/old-ui/app/components/ens-input.js
@@ -177,7 +177,7 @@ EnsInput.prototype.ensIconContents = function (recipient) {
       style: {
         color: '#df2265',
         background: 'white',
-      }
+      },
     })
   }
 

--- a/old-ui/app/components/ens-input.js
+++ b/old-ui/app/components/ens-input.js
@@ -150,7 +150,6 @@ EnsInput.prototype.ensIcon = function (recipient) {
       padding: '6px 0px',
       right: '0px',
       transform: 'translatex(-40px)',
-      zIndex: 1000,
     },
   }, this.ensIconContents(recipient))
 }

--- a/old-ui/app/components/ens-input.js
+++ b/old-ui/app/components/ens-input.js
@@ -117,7 +117,7 @@ EnsInput.prototype.lookupEnsName = function () {
       toError: null,
     }
     if (isValidENSAddress(recipient) && reason.message === 'ENS name not defined.') {
-      setStateObj.hoverText = this.context.t('ensNameNotFound')
+      setStateObj.hoverText = 'ENS name not found'
       setStateObj.toError = 'ensNameNotFound'
       setStateObj.ensFailure = false
     } else {
@@ -173,13 +173,18 @@ EnsInput.prototype.ensIconContents = function (recipient) {
   }
 
   if (ensFailure) {
-    return h('i.fa.fa-warning.fa-lg.warning')
+    return h('i.fa.fa-warning.fa-lg.warning', {
+      style: {
+        color: '#df2265',
+        background: 'white',
+      }
+    })
   }
 
   if (ensResolution && (ensResolution !== ZERO_ADDRESS)) {
     return h('i.fa.fa-check-circle.fa-lg.cursor-pointer', {
       style: {
-        color: 'green',
+        color: '#60db97',
         background: 'white',
       },
       onClick: (event) => {

--- a/old-ui/app/components/ens-input.js
+++ b/old-ui/app/components/ens-input.js
@@ -147,8 +147,10 @@ EnsInput.prototype.ensIcon = function (recipient) {
     title: hoverText,
     style: {
       position: 'absolute',
-      padding: '9px',
+      padding: '6px 0px',
+      right: '0px',
       transform: 'translatex(-40px)',
+      zIndex: 1000,
     },
   }, this.ensIconContents(recipient))
 }
@@ -165,6 +167,7 @@ EnsInput.prototype.ensIconContents = function (recipient) {
         width: '30px',
         height: '30px',
         transform: 'translateY(-6px)',
+        marginRight: '-5px',
       },
     })
   }
@@ -175,7 +178,10 @@ EnsInput.prototype.ensIconContents = function (recipient) {
 
   if (ensResolution && (ensResolution !== ZERO_ADDRESS)) {
     return h('i.fa.fa-check-circle.fa-lg.cursor-pointer', {
-      style: { color: 'green' },
+      style: {
+        color: 'green',
+        background: 'white',
+      },
       onClick: (event) => {
         event.preventDefault()
         event.stopPropagation()

--- a/old-ui/app/components/send/send-token.js
+++ b/old-ui/app/components/send/send-token.js
@@ -184,8 +184,16 @@ class SendTransactionScreen extends PersistentForm {
   async onSubmit () {
     const state = this.state || {}
     const { token, amount } = state
-    const recipient = state.recipient || document.querySelector('input[name="address"]').value.replace(/^[.\s]+|[.\s]+$/g, '')
-    const nickname = state.nickname || ' '
+    let recipient = state.recipient || document.querySelector('input[name="address"]').value.replace(/^[.\s]+|[.\s]+$/g, '')
+    let nickname = state.nickname || ' '
+    if (typeof recipient === 'object') {
+      if (recipient.toAddress) {
+        recipient = recipient.toAddress
+      }
+      if (recipient.nickname) {
+        nickname = recipient.nickname
+      }
+    }
     const parts = amount.split('.')
 
     let message

--- a/old-ui/app/components/send/send.js
+++ b/old-ui/app/components/send/send.js
@@ -163,8 +163,16 @@ SendTransactionScreen.prototype.recipientDidChange = function (recipient, nickna
 
 SendTransactionScreen.prototype.onSubmit = function () {
   const state = this.state || {}
-  const recipient = state.recipient || document.querySelector('input[name="address"]').value.replace(/^[.\s]+|[.\s]+$/g, '')
-  const nickname = state.nickname || ' '
+  let recipient = state.recipient || document.querySelector('input[name="address"]').value.replace(/^[.\s]+|[.\s]+$/g, '')
+  let nickname = state.nickname || ' '
+  if (typeof recipient === 'object') {
+    if (recipient.toAddress) {
+      recipient = recipient.toAddress
+    }
+    if (recipient.nickname) {
+      nickname = recipient.nickname
+    }
+  }
   const input = document.querySelector('input[name="amount"]').value
   const parts = input.split('.')
 

--- a/old-ui/app/util.js
+++ b/old-ui/app/util.js
@@ -78,7 +78,10 @@ function miniAddressSummary (address) {
 }
 
 function isValidAddress (address) {
+  console.log('### isValidAddress ###')
+  console.log(address)
   var prefixed = ethUtil.addHexPrefix(address)
+  console.log(prefixed)
   if (address === '0x0000000000000000000000000000000000000000') return false
   return (isAllOneCase(prefixed) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
 }
@@ -88,7 +91,10 @@ function isValidENSAddress (address) {
 }
 
 function isInvalidChecksumAddress (address) {
+  console.log('### isInvalidChecksumAddress ###')
+  console.log(address)
   var prefixed = ethUtil.addHexPrefix(address)
+  console.log(prefixed)
   if (address === '0x0000000000000000000000000000000000000000') return false
   return !isAllOneCase(prefixed) && !ethUtil.isValidChecksumAddress(prefixed) && ethUtil.isValidAddress(prefixed)
 }

--- a/old-ui/app/util.js
+++ b/old-ui/app/util.js
@@ -78,10 +78,7 @@ function miniAddressSummary (address) {
 }
 
 function isValidAddress (address) {
-  console.log('### isValidAddress ###')
-  console.log(address)
   var prefixed = ethUtil.addHexPrefix(address)
-  console.log(prefixed)
   if (address === '0x0000000000000000000000000000000000000000') return false
   return (isAllOneCase(prefixed) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
 }
@@ -91,10 +88,7 @@ function isValidENSAddress (address) {
 }
 
 function isInvalidChecksumAddress (address) {
-  console.log('### isInvalidChecksumAddress ###')
-  console.log(address)
   var prefixed = ethUtil.addHexPrefix(address)
-  console.log(prefixed)
   if (address === '0x0000000000000000000000000000000000000000') return false
   return !isAllOneCase(prefixed) && !ethUtil.isValidChecksumAddress(prefixed) && ethUtil.isValidAddress(prefixed)
 }


### PR DESCRIPTION
**Problem**: The validation on *Send* screen doesn't allow ENS names for the recipient. Also, ENS lookup status icons are improperly aligned and improperly branded.

Hotfixes:

- ENS validation fix for Send transaction screens
- ENS lookup status icon alignment fix
- ENS lookup statuses icons colours have been refined to fit the colour scheme of the whole extension

Also, I'd like to mention, that *Send component* will be refactored in the near future with the allocation of Base parent *Send* component and derived from it *Send* components for tokens, contracts.