### PR TITLE
NW release 4.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Current Master
 
+## 4.11.3 Fri Mar 29 2019
+
+- [#272](https://github.com/poanetwork/nifty-wallet/pull/272): Update Classic RPC endpoint
+
 ## 4.11.2 Wed Mar 27 2019
 
 - [#270](https://github.com/poanetwork/nifty-wallet/pull/270): (Feature) Support of gas price oracles for ETH, ETC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 4.11.2 Wed Mar 27 2019
 
+- [#270](https://github.com/poanetwork/nifty-wallet/pull/270): (Feature) Support of gas price oracles for ETH, ETC
 - [#268](https://github.com/poanetwork/nifty-wallet/pull/268): (Feature) Support of Ethereum Classic chain
 
 ## 4.11.1 Wed Mar 20 2019

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "__MSG_appName__",
-  "version": "4.11.2",
+  "version": "4.11.3",
   "manifest_version": 2,
   "author": "POA Network",
   "description": "__MSG_appDescription__",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10823,9 +10823,9 @@
       }
     },
     "eth-net-props": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/eth-net-props/-/eth-net-props-1.0.20.tgz",
-      "integrity": "sha512-9oi1HMQ/3FixfzPxUqr2gB62It9DLoFIqZ7LI0pmHvZJz6PlHIengqA/JjSc9TgIjlOiSeKxnZ8V3eX6u3wBEA==",
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/eth-net-props/-/eth-net-props-1.0.21.tgz",
+      "integrity": "sha512-XDeCkRuCSFv37bQgUPvVizt1kWD3MfF8WuQfwECUC6kVb6hZZ/qzw0rImLpxvrr3yHduwRtgm6ZOIGMMqA6yJg==",
       "requires": {
         "chai": "^4.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "eth-keychain-controller": "github:vbaranov/KeyringController#simple-address",
     "eth-ledger-bridge-keyring": "github:vbaranov/eth-ledger-bridge-keyring#0.1.0-clear-accounts-flag",
     "eth-method-registry": "^1.0.0",
-    "eth-net-props": "^1.0.20",
+    "eth-net-props": "^1.0.21",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",
     "eth-sig-util": "^2.0.2",


### PR DESCRIPTION
- [#272](https://github.com/poanetwork/nifty-wallet/pull/272): Update Classic RPC endpoint
