### PR TITLE
(Fix) Remove js obfuscation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -302,7 +302,7 @@ function createTasksForBuildJsExtension ({ buildJsFiles, taskPrefix, devMode, bu
   bundleTaskOpts = Object.assign({
     buildSourceMaps: true,
     sourceMapDir: devMode ? './' : '../sourcemaps',
-    minifyBuild: !devMode,
+    minifyBuild: false,
     buildWithFullPaths: devMode,
     watch: devMode,
     devMode,
@@ -318,7 +318,7 @@ function createTasksForBuildJsMascara ({ taskPrefix, devMode, bundleTaskOpts = {
   bundleTaskOpts = Object.assign({
     buildSourceMaps: true,
     sourceMapDir: './',
-    minifyBuild: !devMode,
+    minifyBuild: false,
     buildWithFullPaths: devMode,
     watch: devMode,
     devMode,


### PR DESCRIPTION
Remove js obfuscation in the production build to fit "New code readability requirements" in [Google Chrome extensions development guidelines](https://blog.chromium.org/2018/10/trustworthy-chrome-extensions-by-default.html)