### PR TITLE
NW release 4.11.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Current Master
 
+## 4.11.5 Thu Apr 18 2019
+
+- [#279](https://github.com/poanetwork/nifty-wallet/pull/279): (Fix) utf8 encoding in contentscript.js
+
 ## 4.11.4 Mon Apr 15 2019
 
 - [#277](https://github.com/poanetwork/nifty-wallet/pull/277): (Fix) USD price for ETC coin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Current Master
 
+## 4.11.4 Mon Apr 15 2019
+
+- [#277](https://github.com/poanetwork/nifty-wallet/pull/277): (Fix) USD price for ETC coin
+- [#276](https://github.com/poanetwork/nifty-wallet/pull/276): (Fix) Remove js obfuscation
+
 ## 4.11.3 Fri Mar 29 2019
 
 - [#272](https://github.com/poanetwork/nifty-wallet/pull/272): Update Classic RPC endpoint

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "__MSG_appName__",
-  "version": "4.11.3",
+  "version": "4.11.4",
   "manifest_version": 2,
   "author": "POA Network",
   "description": "__MSG_appDescription__",

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "__MSG_appName__",
   "short_name": "__MSG_appName__",
-  "version": "4.11.4",
+  "version": "4.11.5",
   "manifest_version": 2,
   "author": "POA Network",
   "description": "__MSG_appDescription__",


### PR DESCRIPTION
- [#279](https://github.com/poanetwork/nifty-wallet/pull/279): (Fix) utf8 encoding instead of buffer for embedding inpage.js into contentscript.js