### PR TITLE
Address checksum for RSK chains. RSKIP60

### DIFF
--- a/old-ui/app/account-detail.js
+++ b/old-ui/app/account-detail.js
@@ -4,12 +4,11 @@ const Component = require('react').Component
 const h = require('react-hyperscript')
 const connect = require('react-redux').connect
 const actions = require('../../ui/app/actions')
-const { getCurrentKeyring, ifContractAcc, valuesFor } = require('./util')
+const { getCurrentKeyring, ifContractAcc, valuesFor, toChecksumAddress } = require('./util')
 const Identicon = require('./components/identicon')
 const EthBalance = require('./components/eth-balance')
 const TransactionList = require('./components/transaction-list')
 const ExportAccountView = require('./components/account-export')
-const ethUtil = require('ethereumjs-util')
 const EditableLabel = require('./components/editable-label')
 const TabBar = require('./components/tab-bar')
 const TokenList = require('./components/token-list')
@@ -50,11 +49,11 @@ function AccountDetailScreen () {
 
 AccountDetailScreen.prototype.render = function () {
   var props = this.props
+  const { network, conversionRate, currentCurrency } = props
   var selected = props.address || Object.keys(props.accounts)[0]
-  var checksumAddress = selected && ethUtil.toChecksumAddress(selected)
+  var checksumAddress = selected && toChecksumAddress(network, selected)
   var identity = props.identities[selected]
   var account = props.accounts[selected]
-  const { network, conversionRate, currentCurrency } = props
 
   if (Object.keys(props.suggestedTokens).length > 0) {
     this.props.dispatch(actions.showAddSuggestedTokenPage())

--- a/old-ui/app/account-qr.js
+++ b/old-ui/app/account-qr.js
@@ -5,6 +5,7 @@ const {qrcode: qrCode} = require('qrcode-npm')
 const {connect} = require('react-redux')
 const {isHexPrefixed} = require('ethereumjs-util')
 const CopyButton = require('./components/copy/copy-button')
+const { toChecksumAddress } = require('./util')
 
 class AccountQrScreen extends PureComponent {
   static defaultProps = {
@@ -14,11 +15,13 @@ class AccountQrScreen extends PureComponent {
   static propTypes = {
     Qr: PropTypes.object.isRequired,
     warning: PropTypes.node,
+    network: PropTypes.string,
   }
 
   render () {
-    const {Qr, warning} = this.props
+    const {Qr, warning, network} = this.props
     const address = `${isHexPrefixed(Qr.data) ? 'ethereum:' : ''}${Qr.data}`
+    const addressChecksum = toChecksumAddress(network, Qr.data)
     const qrImage = qrCode(4, 'M')
 
     qrImage.addData(address)
@@ -51,9 +54,9 @@ class AccountQrScreen extends PureComponent {
           style: {
             width: '247px',
           },
-        }, Qr.data),
+        }, addressChecksum),
         h(CopyButton, {
-          value: Qr.data,
+          value: addressChecksum,
         }),
       ]),
     ])
@@ -64,6 +67,7 @@ function mapStateToProps (state) {
   return {
     Qr: state.appState.Qr,
     warning: state.appState.warning,
+    network: state.metamask.network,
   }
 }
 

--- a/old-ui/app/account-qr.js
+++ b/old-ui/app/account-qr.js
@@ -21,7 +21,7 @@ class AccountQrScreen extends PureComponent {
   render () {
     const {Qr, warning, network} = this.props
     const addressChecksum = toChecksumAddress(network, Qr.data)
-    const address = ifRSK ?  addressChecksum : `${isHexPrefixed(Qr.data) ? 'ethereum:' : ''}${Qr.data}`
+    const address = ifRSK ? addressChecksum : `${isHexPrefixed(Qr.data) ? 'ethereum:' : ''}${Qr.data}`
     const qrImage = qrCode(4, 'M')
 
     qrImage.addData(address)

--- a/old-ui/app/account-qr.js
+++ b/old-ui/app/account-qr.js
@@ -5,7 +5,7 @@ const {qrcode: qrCode} = require('qrcode-npm')
 const {connect} = require('react-redux')
 const {isHexPrefixed} = require('ethereumjs-util')
 const CopyButton = require('./components/copy/copy-button')
-const { toChecksumAddress } = require('./util')
+const { toChecksumAddress, ifRSK } = require('./util')
 
 class AccountQrScreen extends PureComponent {
   static defaultProps = {
@@ -20,8 +20,8 @@ class AccountQrScreen extends PureComponent {
 
   render () {
     const {Qr, warning, network} = this.props
-    const address = `${isHexPrefixed(Qr.data) ? 'ethereum:' : ''}${Qr.data}`
     const addressChecksum = toChecksumAddress(network, Qr.data)
+    const address = ifRSK ?  addressChecksum : `${isHexPrefixed(Qr.data) ? 'ethereum:' : ''}${Qr.data}`
     const qrImage = qrCode(4, 'M')
 
     qrImage.addData(address)

--- a/old-ui/app/add-suggested-token.js
+++ b/old-ui/app/add-suggested-token.js
@@ -6,7 +6,7 @@ const actions = require('../../ui/app/actions')
 const Tooltip = require('./components/tooltip.js')
 const ethUtil = require('ethereumjs-util')
 const Copyable = require('./components/copy/copyable')
-const addressSummary = require('./util').addressSummary
+const { addressSummary, toChecksumAddress } = require('./util')
 
 
 module.exports = connect(mapStateToProps)(AddSuggestedTokenScreen)
@@ -30,6 +30,7 @@ AddSuggestedTokenScreen.prototype.render = function () {
   const state = this.state
   const props = this.props
   const { warning } = state
+  const { network } = props
   const key = Object.keys(props.suggestedTokens)[0]
   const { address, symbol, decimals } = props.suggestedTokens[key]
 
@@ -77,7 +78,7 @@ AddSuggestedTokenScreen.prototype.render = function () {
             style: { display: 'flex' },
           }, [
             h(Copyable, {
-            value: ethUtil.toChecksumAddress(address),
+            value: toChecksumAddress(network, address),
             }, [
               h('span#token-address', {
                 style: {
@@ -87,7 +88,7 @@ AddSuggestedTokenScreen.prototype.render = function () {
                   margin: '8px',
                   display: 'flex',
                 },
-              }, addressSummary(address, 24, 4, false)),
+              }, addressSummary(network, address, 24, 4, false)),
             ]),
           ]),
 

--- a/old-ui/app/add-suggested-token.js
+++ b/old-ui/app/add-suggested-token.js
@@ -6,7 +6,7 @@ const actions = require('../../ui/app/actions')
 const Tooltip = require('./components/tooltip.js')
 const ethUtil = require('ethereumjs-util')
 const Copyable = require('./components/copy/copyable')
-const { addressSummary, toChecksumAddress } = require('./util')
+const { addressSummary, toChecksumAddress, isValidAddress } = require('./util')
 
 
 module.exports = connect(mapStateToProps)(AddSuggestedTokenScreen)
@@ -27,12 +27,10 @@ function AddSuggestedTokenScreen () {
 }
 
 AddSuggestedTokenScreen.prototype.render = function () {
-  const state = this.state
-  const props = this.props
-  const { warning } = state
-  const { network } = props
-  const key = Object.keys(props.suggestedTokens)[0]
-  const { address, symbol, decimals } = props.suggestedTokens[key]
+  const { warning } = this.state
+  const { network, suggestedTokens, dispatch } = this.props
+  const key = Object.keys(suggestedTokens)[0]
+  const { address, symbol, decimals } = suggestedTokens[key]
 
   return (
     h('.flex-column.flex-grow', [
@@ -133,7 +131,7 @@ AddSuggestedTokenScreen.prototype.render = function () {
               margin: '8px',
             },
             onClick: (event) => {
-              this.props.dispatch(actions.removeSuggestedTokens())
+              dispatch(actions.removeSuggestedTokens())
             },
           }, 'Cancel'),
 
@@ -146,9 +144,9 @@ AddSuggestedTokenScreen.prototype.render = function () {
               const valid = this.validateInputs({ address, symbol, decimals })
               if (!valid) return
 
-              this.props.dispatch(actions.addToken(address.trim(), symbol.trim(), decimals))
+              dispatch(actions.addToken(address.trim(), symbol.trim(), decimals))
                 .then(() => {
-                  this.props.dispatch(actions.removeSuggestedTokens())
+                  dispatch(actions.removeSuggestedTokens())
                 })
             },
           }, 'Add'),
@@ -163,12 +161,13 @@ AddSuggestedTokenScreen.prototype.componentWillMount = function () {
 }
 
 AddSuggestedTokenScreen.prototype.validateInputs = function (opts) {
+  const { network, identities } = this.props
   let msg = ''
-  const identitiesList = Object.keys(this.props.identities)
+  const identitiesList = Object.keys(identities)
   const { address, symbol, decimals } = opts
   const standardAddress = ethUtil.addHexPrefix(address).toLowerCase()
 
-  const validAddress = ethUtil.isValidAddress(address)
+  const validAddress = isValidAddress(address, network)
   if (!validAddress) {
     msg += 'Address is invalid.'
   }

--- a/old-ui/app/components/account-dropdowns/account-dropdowns.component.js
+++ b/old-ui/app/components/account-dropdowns/account-dropdowns.component.js
@@ -3,10 +3,9 @@ import PropTypes from 'prop-types'
 import actions from '../../../../ui/app/actions'
 import { connect } from 'react-redux'
 import { Dropdown, DropdownMenuItem } from '../dropdown'
-import ethUtil from 'ethereumjs-util'
 import copyToClipboard from 'copy-to-clipboard'
 import ethNetProps from 'eth-net-props'
-import { getCurrentKeyring, ifContractAcc, ifHardwareAcc, getAllKeyRingsAccounts } from '../../util'
+import { getCurrentKeyring, ifContractAcc, ifHardwareAcc, getAllKeyRingsAccounts, toChecksumAddress } from '../../util'
 import { importTypes } from '../../accounts/import/enums'
 import { getFullABI } from '../../accounts/import/helpers'
 import log from 'loglevel'
@@ -217,8 +216,8 @@ class AccountDropdowns extends Component {
   }
 
   copyAddress = () => {
-    const { selected } = this.props
-    const checkSumAddress = selected && ethUtil.toChecksumAddress(selected)
+    const { selected, network } = this.props
+    const checkSumAddress = selected && toChecksumAddress(network, selected)
     copyToClipboard(checkSumAddress)
   }
 

--- a/old-ui/app/components/account-panel.js
+++ b/old-ui/app/components/account-panel.js
@@ -26,7 +26,7 @@ AccountPanel.prototype.render = function () {
     attributes: [
       {
         key: 'Address',
-        value: addressSummary(identity.address),
+        value: addressSummary(state.network, identity.address),
       },
       balanceOrFaucetingIndication(account, isFauceting, state.network),
     ],

--- a/old-ui/app/components/add-token/add-token.component.js
+++ b/old-ui/app/components/add-token/add-token.component.js
@@ -4,7 +4,7 @@ const h = require('react-hyperscript')
 const Tooltip = require('../tooltip.js')
 const TabBar = require('../tab-bar')
 const { checkExistingAddresses } = require('./util')
-const { getCurrentKeyring, ifContractAcc } = require('../../util')
+const { getCurrentKeyring, ifContractAcc, isValidAddress } = require('../../util')
 const TokenList = require('./token-list')
 const TokenSearch = require('./token-search')
 const { tokenInfoGetter } = require('../../../../ui/app/token-util')
@@ -351,7 +351,7 @@ class AddTokenScreen extends Component {
     const { customAddress: address, customSymbol: symbol, customDecimals: decimals } = state
     const standardAddress = ethUtil.addHexPrefix(address).toLowerCase()
 
-    const validAddress = ethUtil.isValidAddress(address)
+    const validAddress = isValidAddress(address, network)
     if (!validAddress) {
       msg += 'Address is invalid.'
     }
@@ -472,7 +472,7 @@ class AddTokenScreen extends Component {
       autoFilled: false,
     })
 
-    const isValidAddress = ethUtil.isValidAddress(customAddress)
+    const isValidAddress = isValidAddress(customAddress, network)
     const standardAddress = ethUtil.addHexPrefix(customAddress).toLowerCase()
 
     let warning

--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -13,8 +13,7 @@ const MiniAccountPanel = require('./mini-account-panel')
 const Copyable = require('./copy/copyable')
 const EthBalance = require('./eth-balance')
 const TokenBalance = require('./token-balance')
-const addressSummary = util.addressSummary
-const accountSummary = util.accountSummary
+const { addressSummary, accountSummary, toChecksumAddress } = util
 const nameForAddress = require('../../lib/contract-namer')
 const BNInput = require('./bn-as-decimal-input')
 const { getEnvironmentType } = require('../../../app/scripts/lib/util')
@@ -240,14 +239,14 @@ PendingTx.prototype.render = function () {
                 }, accountSummary(identity.name, 6, 4)),
 
                 h(Copyable, {
-                  value: ethUtil.toChecksumAddress(address),
+                  value: toChecksumAddress(network, address),
                 }, [
                   h('span.font-small', {
                     style: {
                       fontFamily: 'Nunito Regular',
                       color: 'rgba(255, 255, 255, 0.7)',
                     },
-                  }, addressSummary(address, 6, 4, false)),
+                  }, addressSummary(network, address, 6, 4, false)),
                 ]),
 
                 h('span.font-small', {
@@ -565,17 +564,17 @@ PendingTx.prototype.miniAccountPanelForRecipient = function (isToken, tokensTran
               display: 'inline-block',
               whiteSpace: 'nowrap',
             },
-          }, accountSummary(nameForAddress(to, props.identities)), 6, 4),
+          }, accountSummary(nameForAddress(to, props.identities, props.network)), 6, 4),
 
           h(Copyable, {
-            value: ethUtil.toChecksumAddress(to),
+            value: toChecksumAddress(props.network, to),
           }, [
             h('span.font-small', {
               style: {
                 fontFamily: 'Nunito Regular',
                 color: 'rgba(255, 255, 255, 0.7)',
               },
-            }, addressSummary(to, 6, 4, false)),
+            }, addressSummary(props.network, to, 6, 4, false)),
           ]),
         ]),
       ])

--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -115,7 +115,7 @@ PendingTx.prototype.render = function () {
   const balance = account ? account.balance : '0x0'
 
   // recipient check
-  const isValidAddress = !txParams.to || util.isValidAddress(txParams.to)
+  const isValidAddress = !txParams.to || util.isValidAddress(txParams.to, network)
 
   // Gas
   const gas = txParams.gas

--- a/old-ui/app/components/send/executor-cell.js
+++ b/old-ui/app/components/send/executor-cell.js
@@ -16,12 +16,14 @@ class ExecutorCell extends Component {
 		address: PropTypes.string,
 		identity: PropTypes.object,
 		onClick: PropTypes.func,
+		network: PropTypes.string,
 	}
 
 	render () {
 		const {
 			address,
 			identity,
+			network,
 		} = this.props
 		const { isSelected } = this.state
 
@@ -70,7 +72,7 @@ class ExecutorCell extends Component {
 							style={{ color: 'rgba(255, 255, 255, 0.7)' }}
 						>
 							<div style={{ lineHeight: '16px', fontSize: '14px' }}>
-								{addressSummary(address)}
+								{addressSummary(network, address)}
 							</div>
 						</div>
 					</div>

--- a/old-ui/app/components/send/send-profile.js
+++ b/old-ui/app/components/send/send-profile.js
@@ -59,7 +59,7 @@ class SendProfile extends Component {
 						}}
 					>
 						<div className="send-profile-address" style={{ lineHeight: '16px', fontSize: '14px' }}>
-							{addressSummary(address)}
+							{addressSummary(network, address)}
 						</div>
 					</div>
 					{/* balance */}

--- a/old-ui/app/components/send/send-token.js
+++ b/old-ui/app/components/send/send-token.js
@@ -124,8 +124,8 @@ class SendTransactionScreen extends PersistentForm {
 
   createFreshTokenTracker () {
     this.setState({isLoading: true})
-    const { address, tokenAddress } = this.props
-    if (!isValidAddress(tokenAddress)) return
+    const { address, tokenAddress, network } = this.props
+    if (!isValidAddress(tokenAddress, network)) return
     if (this.tracker) {
       // Clean up old trackers when refreshing:
       this.tracker.stop()
@@ -225,12 +225,12 @@ class SendTransactionScreen extends PersistentForm {
       return this.props.displayWarning(message)
     }
 
-    if ((isInvalidChecksumAddress(recipient))) {
+    if ((isInvalidChecksumAddress(recipient, this.props.network))) {
       message = 'Recipient address checksum is invalid.'
       return this.props.displayWarning(message)
     }
 
-    if (!isValidAddress(recipient) || (!recipient)) {
+    if (!isValidAddress(recipient, this.props.network) || (!recipient)) {
       message = 'Recipient address is invalid.'
       return this.props.displayWarning(message)
     }

--- a/old-ui/app/components/send/send.js
+++ b/old-ui/app/components/send/send.js
@@ -205,12 +205,12 @@ SendTransactionScreen.prototype.onSubmit = function () {
     return this.props.dispatch(actions.displayWarning(message))
   }
 
-  if ((isInvalidChecksumAddress(recipient))) {
+  if ((isInvalidChecksumAddress(recipient, this.props.network))) {
     message = 'Recipient address checksum is invalid.'
     return this.props.dispatch(actions.displayWarning(message))
   }
 
-  if ((!isValidAddress(recipient) && !txData) || (!recipient && !txData)) {
+  if ((!isValidAddress(recipient, this.props.network) && !txData) || (!recipient && !txData)) {
     message = 'Recipient address is invalid.'
     return this.props.dispatch(actions.displayWarning(message))
   }

--- a/old-ui/app/components/shift-list-item.js
+++ b/old-ui/app/components/shift-list-item.js
@@ -152,7 +152,7 @@ ShiftListItem.prototype.renderInfo = function () {
         }, [
           `${props.depositType} to ETH via ShapeShift`,
             h(CopyButton, {
-            value: this.props.depositAddress,
+            value: props.depositAddress,
           })]),
         h('div', {
           style: {
@@ -219,7 +219,7 @@ ShiftListItem.prototype.renderInfo = function () {
             display: 'inline-flex',
           },
         }, [
-          addressSummary(props.response.transaction),
+          addressSummary(props.network, props.response.transaction),
           h(CopyButton, {
             value: this.props.response.transaction,
           }),

--- a/old-ui/app/components/token-cell.js
+++ b/old-ui/app/components/token-cell.js
@@ -5,12 +5,11 @@ const Identicon = require('./identicon')
 const ethNetProps = require('eth-net-props')
 const Dropdown = require('./dropdown').Dropdown
 const DropdownMenuItem = require('./dropdown').DropdownMenuItem
-const ethUtil = require('ethereumjs-util')
 const copyToClipboard = require('copy-to-clipboard')
 const actions = require('../../../ui/app/actions')
 const connect = require('react-redux').connect
 const { MAINNET_CODE } = require('../../../app/scripts/controllers/network/enums')
-import { countSignificantDecimals } from '../util'
+import { countSignificantDecimals, toChecksumAddress } from '../util'
 
 const tokenCellDropDownPrefix = 'token-cell_dropdown_'
 
@@ -132,7 +131,7 @@ TokenCell.prototype.renderTokenOptions = function (menuToTop, ind) {
         {
           closeMenu: () => {},
           onClick: () => {
-            const checkSumAddress = address && ethUtil.toChecksumAddress(address)
+            const checkSumAddress = address && toChecksumAddress(network, address)
             copyToClipboard(checkSumAddress)
           },
         },

--- a/old-ui/app/components/transaction-list-item.js
+++ b/old-ui/app/components/transaction-list-item.js
@@ -14,6 +14,7 @@ const ethNetProps = require('eth-net-props')
 
 const TransactionIcon = require('./transaction-list-item-icon')
 const ShiftListItem = require('./shift-list-item')
+const { ifRSK } = require('../util')
 
 const { POA_CODE,
   DAI_CODE,
@@ -25,7 +26,6 @@ const { POA_CODE,
   GOERLI_TESTNET_CODE,
   CLASSIC_CODE,
   RSK_CODE,
-  RSK_TESTNET_CODE,
 } = require('../../../app/scripts/controllers/network/enums')
 
 const mapDispatchToProps = dispatch => {
@@ -165,7 +165,7 @@ TransactionListItem.prototype.render = function () {
         }, [
           domainField(txParams),
           h('div.flex-row', [
-            recipientField(txParams, transaction, isTx, isMsg, numericNet),
+            recipientField(txParams, transaction, isTx, isMsg, network),
           ]),
           h('div', {
             style: {
@@ -240,13 +240,13 @@ function domainField (txParams) {
   ])
 }
 
-function recipientField (txParams, transaction, isTx, isMsg, numericNet) {
+function recipientField (txParams, transaction, isTx, isMsg, network) {
   let message
 
   if (isMsg) {
     message = 'Signature Requested'
   } else if (txParams.to) {
-    message = addressSummary(txParams.to)
+    message = addressSummary(network, txParams.to)
   } else {
     message = 'Contract Deployment'
   }
@@ -260,7 +260,7 @@ function recipientField (txParams, transaction, isTx, isMsg, numericNet) {
     h('span', (!txParams.to ? {style: {whiteSpace: 'nowrap'}} : null), message),
     // Places a copy button if tx is successful, else places a placeholder empty div.
     transaction.hash ? h(CopyButton, { value: transaction.hash, display: 'inline' }) : h('div', {style: { display: 'flex', alignItems: 'center', width: '26px' }}),
-    renderErrorOrWarning(transaction, numericNet),
+    renderErrorOrWarning(transaction, network),
   ])
 }
 
@@ -268,7 +268,7 @@ function formatDate (date) {
   return vreme.format(new Date(date), 'March 16 2014 14:30')
 }
 
-function renderErrorOrWarning (transaction, numericNet) {
+function renderErrorOrWarning (transaction, network) {
   const { status, err, warning } = transaction
 
   // show dropped
@@ -295,7 +295,7 @@ function renderErrorOrWarning (transaction, numericNet) {
   }
 
   // show warning
-  const isRSK = numericNet === RSK_CODE || numericNet === RSK_TESTNET_CODE
+  const isRSK = ifRSK(network)
   if (warning && !isRSK || (isRSK && !warning.error.includes('[ethjs-rpc] rpc error with payload'))) {
     const message = warning.message
     return h(Tooltip, {

--- a/old-ui/app/components/transaction-list-item.js
+++ b/old-ui/app/components/transaction-list-item.js
@@ -296,7 +296,7 @@ function renderErrorOrWarning (transaction, network) {
 
   // show warning
   const isRSK = ifRSK(network)
-  if (warning && !isRSK || (isRSK && !warning.error.includes('[ethjs-rpc] rpc error with payload'))) {
+  if (warning && !isRSK || (isRSK && warning && !warning.error.includes('[ethjs-rpc] rpc error with payload'))) {
     const message = warning.message
     return h(Tooltip, {
       title: message,

--- a/old-ui/app/util.js
+++ b/old-ui/app/util.js
@@ -81,11 +81,9 @@ function accountSummary (acc, firstSegLength = 6, lastSegLength = 4) {
 function isValidAddress (address, network) {
   var prefixed = ethUtil.addHexPrefix(address)
   if (ifRSK(network)) {
-    // console.log('addHexPrefixRSK:', prefixed)
     if (address === '0x0000000000000000000000000000000000000000') return false
     return (ethUtil.isValidAddress(prefixed))
   } else {
-    // console.log('addHexPrefix:', prefixed)
     if (address === '0x0000000000000000000000000000000000000000') return false
     return (isAllOneCase(prefixed) && ethUtil.isValidAddress(prefixed)) || ethUtil.isValidChecksumAddress(prefixed)
   }
@@ -414,9 +412,5 @@ function toChecksumAddress (network, address, chainId = null) {
 }
 
 function isValidChecksumAddress (network, address) {
-  // console.log('isValidAddress(address):', isValidAddress(address, network))
-  // console.log('toChecksumAddress(network, address) === address', toChecksumAddress(network, address) === address)
-  // console.log('ethUtil.isValidAddress(address)', ethUtil.isValidAddress(address))
-  // console.log('isAllOneCase', isAllOneCase(address))
   return isValidAddress(address, network) && toChecksumAddress(network, address) === address
 }

--- a/old-ui/app/util.js
+++ b/old-ui/app/util.js
@@ -390,7 +390,7 @@ function ifRSK (network) {
 function toChecksumAddressRSK (address, chainId = null) {
   const zeroX = '0x'
   const stripAddress = ethUtil.stripHexPrefix(address).toLowerCase()
-  const prefix = chainId != null ? (chainId.toString() + zeroX) : ''
+  const prefix = chainId !== null ? (chainId.toString() + zeroX) : ''
   const keccakHash = ethUtil.sha3(prefix + stripAddress).toString('hex')
   let output = zeroX
 

--- a/old-ui/lib/contract-namer.js
+++ b/old-ui/lib/contract-namer.js
@@ -6,10 +6,10 @@
  */
 
 const contractMap = require('eth-contract-metadata')
-const ethUtil = require('ethereumjs-util')
+const { toChecksumAddress } = require('../app/util')
 
-module.exports = function (addr, identities = {}) {
-  const checksummed = ethUtil.toChecksumAddress(addr)
+module.exports = function (addr, identities = {}, network) {
+  const checksummed = toChecksumAddress(network, addr)
   if (contractMap[checksummed] && contractMap[checksummed].name) {
     return contractMap[checksummed].name
   }

--- a/old-ui/lib/icon-factory.js
+++ b/old-ui/lib/icon-factory.js
@@ -1,9 +1,9 @@
 var iconFactory
 const isValidAddress = require('ethereumjs-util').isValidAddress
-const toChecksumAddress = require('ethereumjs-util').toChecksumAddress
 const contractMapETH = require('eth-contract-metadata')
 const contractMapPOA = require('poa-contract-metadata')
 const colors = require('../../colors')
+const { toChecksumAddress } = require('../app/util')
 
 module.exports = function (rockicon) {
   if (!iconFactory) {
@@ -20,7 +20,7 @@ function IconFactory (rockicon) {
 
 IconFactory.prototype.iconForAddress = function (address, diameter, network) {
   const networkID = parseInt(network)
-  const addr = toChecksumAddress(address)
+  const addr = toChecksumAddress(network, address)
   if (iconExistsFor(addr, networkID)) {
     return imageElFor(addr, networkID)
   }

--- a/old-ui/lib/lost-accounts-notice.js
+++ b/old-ui/lib/lost-accounts-notice.js
@@ -4,14 +4,14 @@ module.exports = function (lostAccounts) {
   return {
     date: new Date().toDateString(),
     title: 'Account Problem Caught',
-    body: `MetaMask has fixed a bug where some accounts were previously mis-generated. This was a rare issue, but you were affected!
+    body: `NiftyWallet has fixed a bug where some accounts were previously mis-generated. This was a rare issue, but you were affected!
 
 We have successfully imported the accounts that were mis-generated, but they will no longer be recovered with your normal seed phrase.
 
 We have marked the affected accounts as "Loose", and recommend you transfer ether and tokens away from those accounts, or export & back them up elsewhere.
 
 Your affected accounts are:
-${lostAccounts.map(acct => ` - ${summary(acct)}`).join('\n')}
+${lostAccounts.map(acct => ` - ${summary(null, acct)}`).join('\n')}
 
 These accounts have been marked as "Loose" so they will be easy to recognize in the account list.
 

--- a/test/unit/old-ui/app/util.spec.js
+++ b/test/unit/old-ui/app/util.spec.js
@@ -13,6 +13,9 @@ const {
   normalizeEthStringToWei,
   normalizeNumberToWei,
   isHex,
+  ifRSK,
+  toChecksumAddress,
+  isValidChecksumAddress,
 } = require('../../../../old-ui/app/util')
 const ethUtil = require('ethereumjs-util')
 let ethInWei = '1'
@@ -327,6 +330,45 @@ describe('normalizing values', function () {
     it('should return true when given a hex string with hex-prefix', function () {
       var result = isHex('0xc3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
       assert(result)
+    })
+  })
+
+  describe('#ifRSK', function () {
+    it('checks if this is RSK chain', function () {
+      var result1 = ifRSK(30)
+      assert(result1)
+      var result2 = ifRSK(31)
+      assert(result2)
+      var result3 = ifRSK(1)
+      assert(!result3)
+      var result4 = ifRSK()
+      assert(!result4)
+    })
+  })
+
+  const addr = '0xB707b030A7887a21cc595Cd139746A8c2Ed91615'
+  const addrRSKMainnet = '0xB707b030A7887a21Cc595cD139746A8c2ED91615'
+  const addrRSKTestnet = '0xB707b030a7887a21Cc595CD139746a8C2ED91615'
+  const addrETHMainnet = '0xB707b030A7887a21cc595Cd139746A8c2Ed91615'
+  describe('#toChecksumAddress', function () {
+    it('calculates correct checksum', function () {
+      var resultMainnet = toChecksumAddress('30', addr)
+      assert.equal(resultMainnet, addrRSKMainnet)
+      var resultTestnet = toChecksumAddress('31', addr)
+      assert.equal(resultTestnet, addrRSKTestnet)
+      var resultNotRSK = toChecksumAddress('1', addr)
+      assert.equal(resultNotRSK, addrETHMainnet)
+    })
+  })
+
+  describe('#isValidChecksumAddress', function () {
+    it('checks if is valid checksum address', function () {
+      var resultMainnet = isValidChecksumAddress('30', addrRSKMainnet)
+      assert(resultMainnet)
+      var resultTestnet = isValidChecksumAddress('31', addrRSKTestnet)
+      assert(resultTestnet)
+      var resultNotRSK = isValidChecksumAddress('1', addrETHMainnet)
+      assert(resultNotRSK)
     })
   })
 })

--- a/test/unit/old-ui/app/util.spec.js
+++ b/test/unit/old-ui/app/util.spec.js
@@ -90,13 +90,13 @@ describe('ifContractAcc(keyring) function', () => {
 describe('#addressSummary', function () {
   it('should add case-sensitive checksum', function () {
     const address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825'
-    const result = addressSummary(address)
+    const result = addressSummary(1, address)
     assert.equal(result, '0xFDEa65C8...b825')
   })
 
   it('should accept arguments for firstseg, lastseg, and keepPrefix', function () {
     const address = '0xfdea65c8e26263f6d9a1b5de9555d2931a33b825'
-    const result = addressSummary(address, 4, 4, false)
+    const result = addressSummary(1, address, 4, 4, false)
     assert.equal(result, 'FDEa...b825')
   })
 })


### PR DESCRIPTION
Address checksum in RSK chains differs from Ethereum chains specification. In Ethereum chains it is standardized with [EIP-155] (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md). Whereas it follows [RSKIP60](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP60) for RSK.

This PR implements RSKIP60.

Address checksum example in different chains:
0xDf682CB153E8af3E13E90e9ACD79a39DDe98eBd8 (ETH Mainnet)
0xdF682cb153E8AF3E13E90e9aCD79A39Dde98EBD8 (RSK Mainnet)
0xdf682cb153e8af3e13e90E9aCD79A39DDe98eBd8 (RSK Testnet)
