### PR TITLE
gas price for RSK from the last block

### DIFF
--- a/old-ui/app/util.js
+++ b/old-ui/app/util.js
@@ -1,6 +1,9 @@
 const ethUtil = require('ethereumjs-util')
 const ethNetProps = require('eth-net-props')
 const {
+  POA_SOKOL_CODE,
+  POA_CODE,
+  DAI_CODE,
   RSK_CODE,
   RSK_TESTNET_CODE,
 } = require('../../app/scripts/controllers/network/enums')
@@ -51,6 +54,7 @@ module.exports = {
   ifHardwareAcc,
   getAllKeyRingsAccounts,
   ifRSK,
+  ifPOA,
   toChecksumAddress,
   isValidChecksumAddress,
 }
@@ -385,6 +389,12 @@ function ifRSK (network) {
   if (!network) return false
   const numericNet = isNaN(network) ? network : parseInt(network)
   return numericNet === RSK_CODE || numericNet === RSK_TESTNET_CODE
+}
+
+function ifPOA (network) {
+  if (!network) return false
+  const numericNet = isNaN(network) ? network : parseInt(network)
+  return numericNet === POA_SOKOL_CODE || numericNet === POA_CODE || numericNet === DAI_CODE
 }
 
 function toChecksumAddressRSK (address, chainId = null) {

--- a/test/unit/old-ui/app/util.spec.js
+++ b/test/unit/old-ui/app/util.spec.js
@@ -14,6 +14,7 @@ const {
   normalizeNumberToWei,
   isHex,
   ifRSK,
+  ifPOA,
   toChecksumAddress,
   isValidChecksumAddress,
 } = require('../../../../old-ui/app/util')
@@ -342,6 +343,22 @@ describe('normalizing values', function () {
       var result3 = ifRSK(1)
       assert(!result3)
       var result4 = ifRSK()
+      assert(!result4)
+    })
+  })
+
+
+  describe('#ifPOA', function () {
+    it('checks if this is POA chain', function () {
+      var resultSokol = ifPOA(77)
+      assert(resultSokol)
+      var resultCore = ifPOA(99)
+      assert(resultCore)
+      var resultXDai = ifPOA(100)
+      assert(resultXDai)
+      var resultMainnet = ifPOA(1)
+      assert(!resultMainnet)
+      var result4 = ifPOA()
       assert(!result4)
     })
   })


### PR DESCRIPTION
https://github.com/poanetwork/nifty-wallet/issues/301

What is implemented: Nifty wallet gets a gas price from `minimumGasPrice` property from the response of `eth_getBlockByHash` JSON RPC method from the last block.