### PR TITLE
Fix pasting of ABI for contract type account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- [#318](https://github.com/poanetwork/nifty-wallet/pull/318) - (Fix) pasting of ABI for contract type account
+
 ## 4.11.10 Tue Feb 04 2020
 
 - [#313](https://github.com/poanetwork/nifty-wallet/pull/313) - Change Ethereum classic RPC endpoint

--- a/old-ui/app/accounts/import/contract.js
+++ b/old-ui/app/accounts/import/contract.js
@@ -41,13 +41,13 @@ class ContractImportView extends Component {
     })
   }
 
-  abiOnChange (abi) {
+  abiOnChange (abi, APIInputDisabled) {
     this.props.hideWarning()
     try {
       if (abi) {
         this.setState({
-          abi: JSON.stringify(abi),
-          abiInputDisabled: true,
+          abi: abi,
+          abiInputDisabled: APIInputDisabled || false,
           importDisabled: false,
         })
       }
@@ -124,7 +124,15 @@ class ContractImportView extends Component {
       return
     }
     getFullABI(web3.eth, contractAddr, network, type)
-      .then(finalABI => this.abiOnChange(finalABI))
+      .then(finalABI => {
+        if (finalABI) {
+          finalABI = JSON.stringify(finalABI)
+          const APIInputDisabled = true
+          return this.abiOnChange(finalABI, APIInputDisabled)
+        } else {
+          return null
+        }
+      })
       .catch(e => {
         this.clearAbi()
         log.debug(e)


### PR DESCRIPTION
Currently, pasting of ABI of non-verified contract lead to the error of importing contract type account.