### PR TITLE
Check stateMutability prop to define if this is reading method

### DIFF
--- a/old-ui/app/components/send/send-contract.js
+++ b/old-ui/app/components/send/send-contract.js
@@ -161,9 +161,10 @@ class SendTransactionScreen extends PersistentForm {
 						options={this.state.options}
 						style={{ marginBottom: '10px' }}
 						onChange={(opt) => {
+							const isConstantMethod = opt.metadata && (opt.metadata.constant || opt.metadata.stateMutability === 'view')
 							this.setState({
 								methodSelected: opt.value,
-								isConstantMethod: opt.metadata.constant,
+								isConstantMethod: isConstantMethod,
 								methodABI: opt.metadata,
 								outputValues: {},
 								inputValues: {},


### PR DESCRIPTION
## Motivation

Definition of reading function for *Contract* type is broken for contracts compiled with newer versions of Solidity compiler. 