### PR TITLE
Update in-page provider (EIP-1193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 5.0.0 Tue Mar 31 2020
 
-- [#340](https://github.com/poanetwork/nifty-wallet/pull/340) - (Feature) Update in-page provider (EIP-1193)
+- [#340](https://github.com/poanetwork/nifty-wallet/pull/340), [#342](https://github.com/poanetwork/nifty-wallet/pull/342) - (Feature) Update in-page provider (EIP-1193)
 - [#334](https://github.com/poanetwork/nifty-wallet/pull/334) - (Feature) Ability to set tx value for payable methods
 - [#333](https://github.com/poanetwork/nifty-wallet/pull/333) - (Fix) Support RSK testnet explorer links
 - [#332](https://github.com/poanetwork/nifty-wallet/pull/332) - (Chore) Return to main screen from removal of imported account

--- a/app/scripts/controllers/permissions/enums.js
+++ b/app/scripts/controllers/permissions/enums.js
@@ -78,4 +78,5 @@ export const SAFE_METHODS = [
   'wallet_watchAsset',
   'eth_getEncryptionPublicKey',
   'eth_decrypt',
+  'eth_accounts',
 ]

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -102,10 +102,6 @@ proxiedInpageProvider._web3Ref = web3.eth
 
 setupDappAutoReload(web3, inpageProvider.publicConfigStore)
 
-// set web3 defaultAccount
-inpageProvider.publicConfigStore.subscribe(function (state) {
-  web3.eth.defaultAccount = state.selectedAddress
-})
 //
 // end deprecate:Q1-2020
 //

--- a/package-lock.json
+++ b/package-lock.json
@@ -44881,18 +44881,54 @@
       "dev": true
     },
     "nifty-wallet-inpage-provider": {
-      "version": "github:poanetwork/nifty-wallet-inpage-provider#3cd5e332d1311fcadd05f3b48b049d7cbf657afc",
-      "from": "github:poanetwork/nifty-wallet-inpage-provider#1.3.0",
+      "version": "github:poanetwork/nifty-wallet-inpage-provider#97f6cbf3ff1684382a3243e60a51f23d213259ca",
+      "from": "github:poanetwork/nifty-wallet-inpage-provider#1.4.0",
       "requires": {
         "eth-json-rpc-errors": "^2.0.2",
         "fast-deep-equal": "^2.0.1",
-        "json-rpc-engine": "^5.1.5",
-        "json-rpc-middleware-stream": "^2.1.1",
+        "json-rpc-engine": "^3.7.4",
+        "json-rpc-middleware-stream": "^2.0.0",
         "loglevel": "^1.6.1",
         "obj-multiplex": "^1.0.0",
-        "obs-store": "^4.0.3",
+        "obs-store": "^3.0.0",
         "pump": "^3.0.0",
         "safe-event-emitter": "^1.0.1"
+      },
+      "dependencies": {
+        "babelify": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+          "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
+          "requires": {
+            "babel-core": "^6.0.14",
+            "object-assign": "^4.0.0"
+          }
+        },
+        "json-rpc-engine": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.8.0.tgz",
+          "integrity": "sha512-6QNcvm2gFuuK4TKU1uwfH0Qd/cOSb9c1lls0gbnIhciktIUQJwz6NQNAW4B1KiGPenv7IKu97V222Yo1bNhGuA==",
+          "requires": {
+            "async": "^2.0.1",
+            "babel-preset-env": "^1.7.0",
+            "babelify": "^7.3.0",
+            "json-rpc-error": "^2.0.0",
+            "promise-to-callback": "^1.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        },
+        "obs-store": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/obs-store/-/obs-store-3.0.2.tgz",
+          "integrity": "sha512-GzBr7KM2TYWoJSlF3sVo1cMIOeyxgXpEdegXLZyYONRpunFHsBdKwOba0ki17kN2stLaEwTNolJChGHafqM7Fw==",
+          "requires": {
+            "babel-preset-es2015": "^6.22.0",
+            "babelify": "^7.3.0",
+            "readable-stream": "^2.2.2",
+            "through2": "^2.0.3",
+            "xtend": "^4.0.1"
+          }
+        }
       }
     },
     "nise": {

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "mkdirp": "^0.5.1",
     "multihashes": "^0.4.12",
     "nanoid": "^2.1.6",
-    "nifty-wallet-inpage-provider": "github:poanetwork/nifty-wallet-inpage-provider#1.3.0",
+    "nifty-wallet-inpage-provider": "github:poanetwork/nifty-wallet-inpage-provider#1.4.0",
     "nonce-tracker": "^1.0.0",
     "number-to-bn": "^1.7.0",
     "obj-multiplex": "^1.0.0",


### PR DESCRIPTION
https://github.com/poanetwork/nifty-wallet/issues/217
https://github.com/poanetwork/nifty-wallet/issues/325
Continuation of https://github.com/poanetwork/nifty-wallet/pull/340

- `ethereum` object extended with `selectedAddress`, `networkVersion`, `chainId` properties
- `_state` object extended with `isConnnected`, `isUnlocked` properties
- the provider emits `chainChanged` on connect to a new chain
- the provider emits `close` on disconnect from a network
- the provider emits `connect` on connect to a network
- all subscriptions from the node emit on `notification`

In overall, the current Nifty Wallet in-page provider should coincide MetaMask's 7.7.8 in-page provider