### PR TITLE
Increase max token symbol length up to 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- [#366](https://github.com/poanetwork/nifty-wallet/pull/366) - (Fix) Increase max token symbol length up to 12
 - [#363](https://github.com/poanetwork/nifty-wallet/pull/363) - (Fix) token decimals display in pending tx screen
 
 ## 5.0.2 Thu Apr 16 2020

--- a/old-ui/app/components/add-token/add-token.component.js
+++ b/old-ui/app/components/add-token/add-token.component.js
@@ -368,9 +368,9 @@ export default class AddTokenScreen extends Component {
     }
 
     const symbolLen = symbol.trim().length
-    const validSymbol = symbolLen > 0 && symbolLen < 12
+    const validSymbol = symbolLen > 0 && symbolLen < 23
     if (!validSymbol) {
-      msg += 'Symbol must be between 0 and 12 characters.'
+      msg += 'Symbol must be between 0 and 23 characters.'
     }
 
     let ownAddress = identitiesList.includes(standardAddress)
@@ -527,8 +527,8 @@ export default class AddTokenScreen extends Component {
     const symbolLength = customSymbol.length
     let customSymbolError = null
 
-    if (symbolLength <= 0 || symbolLength >= 12) {
-      customSymbolError = 'Symbol must be between 0 and 12 characters.' /* this.context.t('symbolBetweenZeroTen')*/
+    if (symbolLength <= 0 || symbolLength >= 23) {
+      customSymbolError = 'Symbol must be between 0 and 23 characters.' /* this.context.t('symbolBetweenZeroTen')*/
     }
 
     this.setState({ customSymbol, customSymbolError })

--- a/old-ui/app/components/add-token/add-token.component.js
+++ b/old-ui/app/components/add-token/add-token.component.js
@@ -368,9 +368,9 @@ export default class AddTokenScreen extends Component {
     }
 
     const symbolLen = symbol.trim().length
-    const validSymbol = symbolLen > 0 && symbolLen < 10
+    const validSymbol = symbolLen > 0 && symbolLen < 12
     if (!validSymbol) {
-      msg += 'Symbol must be between 0 and 10 characters.'
+      msg += 'Symbol must be between 0 and 12 characters.'
     }
 
     let ownAddress = identitiesList.includes(standardAddress)
@@ -527,8 +527,8 @@ export default class AddTokenScreen extends Component {
     const symbolLength = customSymbol.length
     let customSymbolError = null
 
-    if (symbolLength <= 0 || symbolLength >= 10) {
-      customSymbolError = 'Symbol must be between 0 and 10 characters.' /* this.context.t('symbolBetweenZeroTen')*/
+    if (symbolLength <= 0 || symbolLength >= 12) {
+      customSymbolError = 'Symbol must be between 0 and 12 characters.' /* this.context.t('symbolBetweenZeroTen')*/
     }
 
     this.setState({ customSymbol, customSymbolError })


### PR DESCRIPTION
Fixes https://github.com/poanetwork/nifty-wallet/issues/365
The rationale to set 22 as maximum is https://etherscan.io/token/0x7fffa79fe475565098951fd187148782337dfc7d ("yDAI+yUSDC+yUSDT+yTUSD")