### PR TITLE
Ability to import Keystore file if it is not secured by password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- [#368](https://github.com/poanetwork/nifty-wallet/pull/368) - (Fix) Ability to import Keystore file if it is not secured by password
 - [#363](https://github.com/poanetwork/nifty-wallet/pull/363) - (Fix) token decimals display in pending tx screen
 
 ## 5.0.2 Thu Apr 16 2020

--- a/old-ui/app/accounts/import/json.js
+++ b/old-ui/app/accounts/import/json.js
@@ -1,9 +1,9 @@
 const Component = require('react').Component
 const h = require('react-hyperscript')
-const connect = require('react-redux').connect
+import { connect } from 'react-redux'
 const actions = require('../../../../ui/app/actions')
 const FileInput = require('react-simple-file-input').default
-const PropTypes = require('prop-types')
+import PropTypes from 'prop-types'
 
 class JsonImportSubview extends Component {
   constructor (props) {
@@ -75,31 +75,26 @@ class JsonImportSubview extends Component {
   }
 
   createNewKeychain () {
+    const { displayWarning, importNewJsonAccount } = this.props
     const { fileContents } = this.state
 
     if (!fileContents) {
       const message = 'You must select a file to import.'
-      return this.props.displayWarning(message)
+      return displayWarning(message)
     }
 
     const passwordInput = document.getElementById('json-password-box')
     const password = passwordInput.value
 
-    if (!password) {
-      const message = 'You must enter a password for the selected file.'
-      return this.props.displayWarning(message)
-    }
-
-    this.props.importNewAccount([ fileContents, password ])
-      // JS runtime requires caught rejections but failures are handled by Redux
-      .catch()
+    importNewJsonAccount([ fileContents, password ])
+      .catch((err) => err && displayWarning(err.message || err))
   }
 }
 
 JsonImportSubview.propTypes = {
   error: PropTypes.string,
   displayWarning: PropTypes.func,
-  importNewAccount: PropTypes.func,
+  importNewJsonAccount: PropTypes.func,
 }
 
 const mapStateToProps = state => {
@@ -112,7 +107,7 @@ const mapDispatchToProps = dispatch => {
   return {
     goHome: () => dispatch(actions.goHome()),
     displayWarning: warning => dispatch(actions.displayWarning(warning)),
-    importNewAccount: options => dispatch(actions.importNewAccount('JSON File', options)),
+    importNewJsonAccount: options => dispatch(actions.importNewAccount('JSON File', options)),
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11369,8 +11369,8 @@
       }
     },
     "eth-hd-keyring": {
-      "version": "github:vbaranov/eth-hd-keyring#2c761c59e7cc978da6a612bf6d9833d8ea95efb5",
-      "from": "github:vbaranov/eth-hd-keyring#2.1.0",
+      "version": "github:vbaranov/eth-hd-keyring#487eec0e853cee95723f2efede99a0c722826b34",
+      "from": "github:vbaranov/eth-hd-keyring#2.1.1",
       "requires": {
         "bip39": "^2.2.0",
         "eth-sig-util": "^2.4.4",
@@ -11632,19 +11632,18 @@
       }
     },
     "eth-keychain-controller": {
-      "version": "github:vbaranov/KeyringController#a39087f825b1cbffc663ef002d7d66ade3c5944b",
-      "from": "github:vbaranov/KeyringController#5.2.0",
+      "version": "github:vbaranov/KeyringController#7c32b3d0d7a35d09d2a85f8f339f499e3df44811",
+      "from": "github:vbaranov/KeyringController#5.3.1",
       "requires": {
         "bip39": "^2.4.0",
         "bluebird": "^3.5.0",
         "browser-passworder": "^2.0.3",
-        "eth-hd-keyring": "github:vbaranov/eth-hd-keyring#2.1.0",
+        "eth-hd-keyring": "github:vbaranov/eth-hd-keyring#2.1.1",
         "eth-sig-util": "^1.4.0",
         "eth-simple-keyring": "^3.5.0",
         "ethereumjs-util": "^5.1.2",
         "loglevel": "^1.5.0",
-        "obs-store": "^4.0.3",
-        "promise-filter": "^1.1.0"
+        "obs-store": "^4.0.3"
       },
       "dependencies": {
         "eth-sig-util": {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "eth-json-rpc-filters": "github:poanetwork/eth-json-rpc-filters#3.0.2",
     "eth-json-rpc-infura": "^4.0.2",
     "eth-json-rpc-middleware": "^4.4.1",
-    "eth-keychain-controller": "github:vbaranov/KeyringController#5.2.0",
+    "eth-keychain-controller": "github:vbaranov/KeyringController#5.3.1",
     "eth-ledger-bridge-keyring": "github:vbaranov/eth-ledger-bridge-keyring#0.1.0-clear-accounts-flag",
     "eth-method-registry": "^1.0.0",
     "eth-net-props": "^1.0.33",


### PR DESCRIPTION
Password is required to import account from JSON Keystore file. But that file can be created without a password. Thus, the wallet should allow import of such JSON keystore files.