### PR TITLE
RSK: fix GasPrice calculation (changed output of minimumGasPrice)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- [#369](https://github.com/poanetwork/nifty-wallet/pull/369) - (Fix) RSK: fix GasPrice calculation (changed interface of minimumGasPrice - hex instead of integer)
 - [#368](https://github.com/poanetwork/nifty-wallet/pull/368) - (Fix) Ability to import Keystore file if it is not secured by password
 - [#366](https://github.com/poanetwork/nifty-wallet/pull/366) - (Fix) Increase max token symbol length up to 12
 - [#363](https://github.com/poanetwork/nifty-wallet/pull/363) - (Fix) token decimals display in pending tx screen

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1886,7 +1886,7 @@ module.exports = class MetamaskController extends EventEmitter {
           resolve(gasPrice)
         }
       } else if (isRSK) {
-        gasPrice = this.getGasPriceFromLastBlockRSK(networkId)
+        gasPrice = this.getGasPriceFromLastBlockRSK()
         resolve(gasPrice)
       } else {
         gasPrice = this.getGasPriceFromBlocks(networkId)
@@ -1937,7 +1937,7 @@ module.exports = class MetamaskController extends EventEmitter {
    * Related issue: https://github.com/poanetwork/nifty-wallet/issues/301
    * @returns {string} A hex representation of the suggested wei gas price.
    */
-  getGasPriceFromLastBlockRSK (networkId) {
+  getGasPriceFromLastBlockRSK () {
     const { recentBlocksController } = this
     const { recentBlocks } = recentBlocksController.store.getState()
 
@@ -1946,10 +1946,8 @@ module.exports = class MetamaskController extends EventEmitter {
 
     const gasPrice = recentBlock && recentBlock.minimumGasPrice
 
-    const gasPriceInt = parseInt(gasPrice, 10)
-
-    if (gasPriceInt !== 0) {
-      return '0x' + gasPriceInt.toString(16)
+    if (gasPrice !== 0) {
+      return gasPrice
     } else {
       return '0x' + GWEI_BN.toString(16)
     }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1944,9 +1944,9 @@ module.exports = class MetamaskController extends EventEmitter {
     const recentBlock = recentBlocks
       .sort((block1, block2) => block1.number - block2.number)[recentBlocks.length - 1]
 
-    const gasPrice = recentBlock && recentBlock.minimumGasPrice
-
-    if (gasPrice !== 0) {
+    const gasPrice = recentBlock && recentBlock.minimumGasPrice && recentBlock.minimumGasPrice.toString()
+    
+    if (gasPrice !== '0x' && gasPrice !== '0x0' && gasPrice !== '') {
       return gasPrice
     } else {
       return '0x' + GWEI_BN.toString(16)

--- a/test/unit/app/controllers/metamask-controller-test.js
+++ b/test/unit/app/controllers/metamask-controller-test.js
@@ -161,9 +161,9 @@ describe('MetaMaskController', function () {
         getState: () => {
           return {
             recentBlocks: [
-              { number: '0x1', minimumGasPrice: '59240010' },
-              { number: '0x2', minimumGasPrice: '59240005' },
-              { number: '0x3', minimumGasPrice: '59240000' },
+              { number: '0x1', minimumGasPrice: '0x387ee48' },
+              { number: '0x2', minimumGasPrice: '0x387ee42' },
+              { number: '0x3', minimumGasPrice: '0x387ee40' },
             ],
           }
         },
@@ -175,7 +175,7 @@ describe('MetaMaskController', function () {
         getState: () => {
           return {
             recentBlocks: [
-              { number: '0x4', minimumGasPrice: '0' },
+              { number: '0x4', minimumGasPrice: '0x' },
             ],
           }
         },


### PR DESCRIPTION
Fix for https://forum.poa.network/t/wrong-value-for-gasprice-when-sending-tokens-rsk-network/3407/2

`minimumGasPrice` property returns hex now instead of number as it was previously.