### PR TITLE
Sign message screen: do not decode message if it is not hex encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Current Master
 
-- [#364](https://github.com/poanetwork/nifty-wallet/pull/364) - Fix notifications order in batch requests
+- [#377](https://github.com/poanetwork/nifty-wallet/pull/377) - (Fix) Sign message screen: do not decode message if it is not hex encoded
+- [#364](https://github.com/poanetwork/nifty-wallet/pull/364) - (Fix) notifications order in batch requests
 
 ## 5.0.3 Fri May 01 2020
 

--- a/old-ui/app/components/binary-renderer.js
+++ b/old-ui/app/components/binary-renderer.js
@@ -1,8 +1,8 @@
-const Component = require('react').Component
+import { Component } from 'react'
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
-const ethUtil = require('ethereumjs-util')
-const extend = require('xtend')
+import ethUtil from 'ethereumjs-util'
+import extend from 'xtend'
 
 module.exports = BinaryRenderer
 
@@ -14,7 +14,7 @@ function BinaryRenderer () {
 BinaryRenderer.prototype.render = function () {
   const props = this.props
   const { value, style } = props
-  const text = this.hexToText(value)
+  const message = this.msgHexToText(value)
 
   const defaultStyle = extend({
     width: '100%',
@@ -30,16 +30,16 @@ BinaryRenderer.prototype.render = function () {
     h('textarea.font-small', {
       readOnly: true,
       style: defaultStyle,
-      defaultValue: text,
+      defaultValue: message,
     })
   )
 }
 
-BinaryRenderer.prototype.hexToText = function (hex) {
+BinaryRenderer.prototype.msgHexToText = (hex) => {
   try {
     const stripped = ethUtil.stripHexPrefix(hex)
     const buff = Buffer.from(stripped, 'hex')
-    return buff.toString('utf8')
+    return buff.length === 32 ? hex : buff.toString('utf8')
   } catch (e) {
     return hex
   }

--- a/test/unit/components/binary-renderer-test.js
+++ b/test/unit/components/binary-renderer-test.js
@@ -12,12 +12,12 @@ describe('BinaryRenderer', function () {
   })
 
   it('recovers message', function () {
-    const result = binaryRenderer.hexToText(hex)
+    const result = binaryRenderer.msgHexToText(hex)
     assert.equal(result, message)
   })
 
   it('recovers message with hex prefix', function () {
-    const result = binaryRenderer.hexToText('0x' + hex)
+    const result = binaryRenderer.msgHexToText('0x' + hex)
     assert.equal(result, message)
   })
 })


### PR DESCRIPTION
An example of an incorrect view of personal message signing in Burner wallet:

![Screenshot 2020-05-04 at 16 39 59](https://user-images.githubusercontent.com/4341812/80971856-07dc4900-8e26-11ea-8a8e-5197659df3e0.png)
