### PR TITLE
Allow Ledger signMessage method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- [#429](https://github.com/poanetwork/nifty-wallet/pull/429) - Allow Ledger signMessage method
+
 ## Current Master
 
 ## 5.2.0 Fri Nov 13 2020

--- a/package-lock.json
+++ b/package-lock.json
@@ -11726,8 +11726,8 @@
       }
     },
     "eth-ledger-bridge-keyring": {
-      "version": "github:vbaranov/eth-ledger-bridge-keyring#c36b34d131a585274e8c7bb69ff985bba4816624",
-      "from": "github:vbaranov/eth-ledger-bridge-keyring#0.1.0-clear-accounts-flag",
+      "version": "github:vbaranov/eth-ledger-bridge-keyring#4f32ca655bca147af4923ef2e58c860d2453366f",
+      "from": "github:vbaranov/eth-ledger-bridge-keyring#0.1.1-clear-accounts-flag",
       "requires": {
         "eth-sig-util": "^1.4.2",
         "ethereumjs-tx": "^1.3.4",
@@ -11746,7 +11746,7 @@
           }
         },
         "ethereumjs-abi": {
-          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
           "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
           "requires": {
             "bn.js": "^4.11.8",
@@ -11754,17 +11754,17 @@
           },
           "dependencies": {
             "ethereumjs-util": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-              "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+              "version": "6.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+              "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
               "requires": {
                 "@types/bn.js": "^4.11.3",
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
+                "elliptic": "^6.5.2",
+                "ethereum-cryptography": "^0.1.3",
                 "ethjs-util": "0.1.6",
-                "keccak": "^2.0.0",
-                "rlp": "^2.2.3",
-                "secp256k1": "^3.0.1"
+                "rlp": "^2.2.3"
               }
             }
           }
@@ -16943,15 +16943,7 @@
           "requires": {
             "eth-json-rpc-middleware": "^4.4.0",
             "eth-rpc-errors": "^3.0.0",
-            "json-rpc-engine": "^5.1.3",
-            "node-fetch": "^2.6.0"
-          },
-          "dependencies": {
-            "node-fetch": {
-              "version": "2.6.1",
-              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-              "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-            }
+            "json-rpc-engine": "^5.1.3"
           }
         },
         "eth-json-rpc-middleware": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "eth-json-rpc-infura": "^4.0.2",
     "eth-json-rpc-middleware": "^4.4.1",
     "eth-keychain-controller": "github:vbaranov/KeyringController#5.3.1",
-    "eth-ledger-bridge-keyring": "github:vbaranov/eth-ledger-bridge-keyring#0.1.0-clear-accounts-flag",
+    "eth-ledger-bridge-keyring": "github:vbaranov/eth-ledger-bridge-keyring#0.1.1-clear-accounts-flag",
     "eth-method-registry": "^1.0.0",
     "eth-net-props": "^1.0.36",
     "eth-phishing-detect": "^1.1.4",


### PR DESCRIPTION
`signMessage` method currently is disabled for Ledger Hardware wallet preventing singing of messages from Gnosis Safe Dapp, for instance. This PR aims to enable this method.