### PR TITLE
Contract interaction: allow array input type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- [#435](https://github.com/poanetwork/nifty-wallet/pull/435) - Allow array input type in contracts interactions
 - [#434](https://github.com/poanetwork/nifty-wallet/pull/434) - Add support of tuple type at interaction with read-only contract methods
 - [#432](https://github.com/poanetwork/nifty-wallet/pull/432) - bump rsk-contract-metadata dependency
 


### PR DESCRIPTION
Currently, Nifty wallet doesn't allow to interact with contract methods which have array input types.

![Screenshot 2020-12-25 at 17 48 17](https://user-images.githubusercontent.com/4341812/103137364-6322ba80-46d9-11eb-95af-4184ee748460.png)
