### PR TITLE
Added BTC Legacy derivation path for RSK. This is useful for BTC-RBTC…

### DIFF
--- a/old-ui/app/components/connect-hardware/util.js
+++ b/old-ui/app/components/connect-hardware/util.js
@@ -22,6 +22,10 @@ function getHdPaths (network) {
         label: `Legacy (MEW / MyCrypto)`,
         value: customHdPaths[networkInteger]['ledger'],
       },
+      {
+        label: `BTC (BTC-RBTC Bridge)`,
+        value: customHdPaths[networkInteger]['ledgerBTC'],
+      },
     ]
   } else {
     hdPaths = [
@@ -41,6 +45,7 @@ function getHdPaths (network) {
 const hdRSKMainnetTrezorPath = `m/44'/137'/0'/0`
 const hdRSKMainnetLedgerPath = `m/44'/137'/0'/0`
 const hdRSKMainnetLedgerLivePath = `m/44'/137'/0'/0`
+const hdRSKMainnetLedgerBTCPath = `m/44'/0'/0'/0`
 
 const hdRSKTestnetTrezorPath = `m/44'/37310'/0'/0`
 const hdRSKTestnetLedgerPath = `m/44'/37310'/0'/0`
@@ -54,6 +59,7 @@ const customHdPaths = {}
 customHdPaths[RSK_CODE] = {
   trezor: hdRSKMainnetTrezorPath,
   ledger: hdRSKMainnetLedgerPath,
+  ledgerBTC: hdRSKMainnetLedgerBTCPath,
   ledgeLive: hdRSKMainnetLedgerLivePath,
 }
 


### PR DESCRIPTION
… conversion

Following conversion guide [here](https://developers.rsk.co/rsk/rbtc/conversion/with-ledger/
) you need to reclaim your RBTC using this derivation path m/44'/0'/0'/0.

At the moment I struggled with several bugs in other crypto wallets (including MyCrypto and MEW) so I added the derivation path here as an option for Ledger.

These is just few lines patch.

